### PR TITLE
Added ExternalConnectionSettings and X509CertificateName to…

### DIFF
--- a/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.schema.mof
+++ b/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.schema.mof
@@ -7,6 +7,8 @@ class MSFT_xExchImapSettings : OMI_BaseResource
     [Write] Boolean AllowServiceRestart; //Whether it is OK to restart the IMAP services after making changes. Defaults to $false.
     [Write] String DomainController; //Optional Domain Controller to connect to
     [Write, ValueMap{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}, Values{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}] String LoginType; //The LoginType to be used for IMAP
+    [Write] String ExternalConnectionSettings[]; //Specifies the host name, port, and encryption type that Exchange uses when IMAP clients connect to their email from the outside
+    [Write] String X509CertificateName; //Specifies the host name in the SSL certificate from the Associated Subject field.
 };
 
 

--- a/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.psm1
+++ b/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.psm1
@@ -20,7 +20,13 @@ function Get-TargetResource
 
         [ValidateSet("PlainTextLogin","PlainTextAuthentication","SecureLogin")]
         [System.String]
-        $LoginType
+        $LoginType,
+
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [System.String]
+        $X509CertificateName
     )
 
     #Load helper module
@@ -40,6 +46,8 @@ function Get-TargetResource
         $returnValue = @{
             Server = $Identity
             LoginType = $pop.LoginType
+            ExternalConnectionSettings = $pop.ExternalConnectionSettings
+            X509CertificateName = $pop.X509CertificateName
         }
     }
 
@@ -68,7 +76,13 @@ function Set-TargetResource
 
         [ValidateSet("PlainTextLogin","PlainTextAuthentication","SecureLogin")]
         [System.String]
-        $LoginType
+        $LoginType,
+
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [System.String]
+        $X509CertificateName
     )
 
     #Load helper module
@@ -79,7 +93,7 @@ function Set-TargetResource
     #Establish remote Powershell session
     GetRemoteExchangeSession -Credential $Credential -CommandsToLoad "Set-PopSettings" -VerbosePreference $VerbosePreference
 
-    RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToRemove "Credential"
+    RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToRemove "Credential","AllowServiceRestart"
 
     Set-PopSettings @PSBoundParameters
 
@@ -118,7 +132,13 @@ function Test-TargetResource
 
         [ValidateSet("PlainTextLogin","PlainTextAuthentication","SecureLogin")]
         [System.String]
-        $LoginType
+        $LoginType,
+
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [System.String]
+        $X509CertificateName
     )
 
     #Load helper module
@@ -129,9 +149,9 @@ function Test-TargetResource
     #Establish remote Powershell session
     GetRemoteExchangeSession -Credential $Credential -CommandsToLoad "Get-PopSettings" -VerbosePreference $VerbosePreference
 
-    RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToKeep "Server","DomainController"
+    SetEmptyStringParamsToNull -PSBoundParametersIn $PSBoundParameters
 
-    $pop = Get-PopSettings @PSBoundParameters
+    $pop = GetPopSettings @PSBoundParameters
 
     if ($pop -eq $null)
     {
@@ -142,12 +162,56 @@ function Test-TargetResource
         if (!(VerifySetting -Name "LoginType" -Type "String" -ExpectedValue $LoginType -ActualValue $pop.LoginType -PSBoundParametersIn $PSBoundParameters -VerbosePreference $VerbosePreference))
         {
             return $false
-        }   
+        }
+
+        if (!(VerifySetting -Name "ExternalConnectionSettings" -Type "Array" -ExpectedValue $ExternalConnectionSettings -ActualValue $pop.ExternalConnectionSettings -PSBoundParametersIn $PSBoundParameters -VerbosePreference $VerbosePreference))
+        {
+            return $false
+        }
+
+        if (!(VerifySetting -Name "X509CertificateName" -Type "String" -ExpectedValue $X509CertificateName -ActualValue $pop.X509CertificateName -PSBoundParametersIn $PSBoundParameters -VerbosePreference $VerbosePreference))
+        {
+            return $false
+        }
     }
 
     return $true
 }
 
+function GetPopSettings
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Server,
+
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [System.Boolean]
+        $AllowServiceRestart = $false,
+
+        [System.String]
+        $DomainController,
+
+        [ValidateSet("PlainTextLogin","PlainTextAuthentication","SecureLogin")]
+        [System.String]
+        $LoginType,
+
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [System.String]
+        $X509CertificateName
+    )
+
+    RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToKeep "Server","DomainController"
+
+    return (Get-PopSettings @PSBoundParameters)
+}
 
 Export-ModuleMember -Function *-TargetResource
 

--- a/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.schema.mof
+++ b/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.schema.mof
@@ -7,6 +7,8 @@ class MSFT_xExchPopSettings : OMI_BaseResource
     [Write] Boolean AllowServiceRestart; //Whether it is OK to restart the POP services after making changes. Defaults to $false.
     [Write] String DomainController; //Optional Domain Controller to connect to
     [Write, ValueMap{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}, Values{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}] String LoginType; //The LoginType to be used for POP
+    [Write] String ExternalConnectionSettings[]; //Specifies the host name, port, and encryption type that Exchange uses when POP3 clients connect to their email from the outside
+    [Write] String X509CertificateName; //Specifies the host name in the SSL certificate from the Associated Subject field.
 };
 
 


### PR DESCRIPTION
xExchPopSettings and xExchImapSettings

Changes to xExchPopSettings and xExchImapSettings:
- Added ExternalConnectionSettings parameter
- Added X509CertificateName parameter
- Removing AllowServiceRestart from PSBoundParameters in Set functions