### PR TITLE
Fixed PSSA issues in MSFT_xExchAutodiscoverVirtualDirectory (Fixes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ Defaults to $false.
     - Added `LogonFormat` parameter.
     - Added `DefaultDomain` parameter.
 * Added FileSystem parameter to xExchDatabaseAvailabilityGroup
+* Fixed PSSA issues in MSFT_xExchAutodiscoverVirtualDirectory
 
 ### 1.6.0.0  
 


### PR DESCRIPTION
These changes fix the few PSSA issues that came up in the MSFT_xExchAutodiscoverVirtualDirectory resource. (#62) 

There is no longer any output when running:
Invoke-ScriptAnalyzer .\DSCResources\MSFT_xExchAutodiscoverVirtualDirectory -ExcludeRule @('PSDSCDscExamplesPresent', 'PSDSCDscTestsPresent')

I also fixed some small capitalization inconsistencies and updated a function name.

No functionality should be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/94)
<!-- Reviewable:end -->
