### PR TITLE
Disable Integrity Checking When Formatting with ReFS

### DIFF
--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
@@ -888,8 +888,8 @@ function PrepareVolume
 
         Start-Sleep -Seconds 15
 
-		Get-Partition -DiskNumber $DiskNumber -PartitionNumber 2| Format-Volume –AllocationUnitSize $UnitSizeBytes –FileSystem REFS –NewFileSystemLabel $Label –SetIntegrityStreams:$false -Confirm:$false
-		Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber 2 -AccessPath $Folder -PassThru | Set-Partition -NoDefaultDriveLetter $true
+        Get-Partition -DiskNumber $DiskNumber -PartitionNumber 2| Format-Volume â€“AllocationUnitSize $UnitSizeBytes â€“FileSystem REFS â€“NewFileSystemLabel $Label â€“SetIntegrityStreams:$false -Confirm:$false
+        Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber 2 -AccessPath $Folder -PassThru | Set-Partition -NoDefaultDriveLetter $true
     }
 }
 

--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
@@ -841,10 +841,8 @@ function SendVolumeMountPointToEndOfList
 function PrepareVolume
 {
     [CmdletBinding()]
-    param([int]$DiskNumber, [string]$Folder, [string]$FileSystem, [string]$UnitSize, [string]$PartitioningScheme, [string]$Label)
-
-    $formatString = "Format FS=$($FileSystem) UNIT=$($UnitSize) Label=$($Label) QUICK"
-
+    param([int]$DiskNumber, [string]$Folder, [ValidateSet("NTFS","REFS")][string]$FileSystem, [string]$UnitSize, [string]$PartitioningScheme, [string]$Label)
+    
     #Initialize the disk and put in MBR format
     StartDiskpart -Commands "select disk $($DiskNumber)","clean" -VerbosePreference $VerbosePreference | Out-Null
     StartDiskpart -Commands "select disk $($DiskNumber)","online disk" -VerbosePreference $VerbosePreference | Out-Null
@@ -867,7 +865,32 @@ function PrepareVolume
     }    
 
     #Create the partition and format the drive
-    StartDiskpart -Commands "select disk $($DiskNumber)","create partition primary","$($formatString)","assign mount=`"$($Folder)`"" -VerbosePreference $VerbosePreference | Out-Null
+    if ($FileSytem -eq "NTFS")
+    {
+        $formatString = "Format FS=$($FileSystem) UNIT=$($UnitSize) Label=$($Label) QUICK"
+
+        StartDiskpart -Commands "select disk $($DiskNumber)","create partition primary","$($formatString)","assign mount=`"$($Folder)`"" -VerbosePreference $VerbosePreference | Out-Null
+    }
+    else #if ($FileSystem -eq "REFS")
+    {
+        StartDiskpart -Commands "select disk $($DiskNumber)","create partition primary" -VerbosePreference $VerbosePreference | Out-Null
+        
+        if ($UnitSize.ToLower().EndsWith("k"))
+        {
+            $UnitSizeBytes = [UInt64]::Parse($UnitSize.Substring(0, $UnitSize.Length - 1)) * 1024
+        }
+        else
+        {
+            $UnitSizeBytes = $UnitSize
+        }
+
+        Write-Verbose "Sleeping for 15 seconds after partition creation."
+
+        Start-Sleep -Seconds 15
+
+		Get-Partition -DiskNumber $DiskNumber -PartitionNumber 2| Format-Volume –AllocationUnitSize $UnitSizeBytes –FileSystem REFS –NewFileSystemLabel $Label –SetIntegrityStreams:$false -Confirm:$false
+		Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber 2 -AccessPath $Folder -PassThru | Set-Partition -NoDefaultDriveLetter $true
+    }
 }
 
 #Adds a mount point to an existing volume

--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
@@ -865,7 +865,7 @@ function PrepareVolume
     }    
 
     #Create the partition and format the drive
-    if ($FileSytem -eq "NTFS")
+    if ($FileSystem -eq "NTFS")
     {
         $formatString = "Format FS=$($FileSystem) UNIT=$($UnitSize) Label=$($Label) QUICK"
 

--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ Defaults to $false.
     - Added `LogonFormat` parameter.
     - Added `DefaultDomain` parameter.
 * Added FileSystem parameter to xExchDatabaseAvailabilityGroup
+* Fixed PSSA issues in MSFT_xExchAutodiscoverVirtualDirectory and MSFT_xExchActiveSyncVirtualDirectory
 * Updated xExchAutoMountPoint to disable Integrity Checking when formatting volumes as ReFS. This aligns with the latest version of DiskPart.ps1 from the Exchange Server Role Requirements Calculator.
 
 ### 1.6.0.0  

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Should be in a format like "1024MB" or "1TB".
 * **PartitioningScheme**: The partitioning scheme for the volume. 
 Defaults to GPT.
 * **UnitSize**: The unit size to use when formatting the disk. 
-Defaults to 64k.
+Defaults to 64k. Specified value should end in a number, indicating bytes, or with a k, indicating the value is kilobytes.
 * **VolumePrefix**: The prefix to give to Exchange Volume folders. 
 Defaults to EXVOL
 
@@ -809,6 +809,7 @@ Defaults to $false.
     - Added `LogonFormat` parameter.
     - Added `DefaultDomain` parameter.
 * Added FileSystem parameter to xExchDatabaseAvailabilityGroup
+* Updated xExchAutoMountPoint to disable Integrity Checking when formatting volumes as ReFS. This aligns with the latest version of DiskPart.ps1 from the Exchange Server Role Requirements Calculator.
 
 ### 1.6.0.0  
 


### PR DESCRIPTION
Updating xExchAutoMountPoint so that ReFS volumes are formatted with Integrity Checking explicitly disabled. This aligns with what DiskPart.ps1 from the Exchange Server Role Requirements Calculator does, and also aligns with the Exchange Preferred Architecture recommendations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/95)
<!-- Reviewable:end -->
