### PR TITLE
Fix PSSA Issues in AntiMalwareScanning (Fixes #61)

### DIFF
--- a/DSCResources/MSFT_xExchAntiMalwareScanning/MSFT_xExchAntiMalwareScanning.psm1
+++ b/DSCResources/MSFT_xExchAntiMalwareScanning/MSFT_xExchAntiMalwareScanning.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -26,7 +28,7 @@ function Get-TargetResource
 
     $agent = Get-TransportAgent -Identity "Malware Agent"
 
-    if ($agent -ne $null)
+    if ($null -ne $agent)
     {
         $returnValue = @{
             Enabled = $agent.Enabled
@@ -38,6 +40,7 @@ function Get-TargetResource
 
 function Set-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     param
     (
@@ -47,6 +50,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -90,6 +94,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -100,6 +105,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -113,7 +119,7 @@ function Test-TargetResource
 
     $agentStatus = Get-TargetResource @PSBoundParameters
 
-    if ($agentStatus -eq $null)
+    if ($null -eq $agentStatus)
     {
         return $false
     }

--- a/README.md
+++ b/README.md
@@ -805,6 +805,8 @@ Defaults to $false.
 
 ### Unreleased
 
+* Fixed PSSA issues in MSFT_xExchAntiMalwareScanning
+
 ### 1.7.0.0
 
 * xExchOwaVirtualDirectory


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchAntiMalwareScanning.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/101)
<!-- Reviewable:end -->
