### PR TITLE
Fix PSSA Issues in ClientAccessServer (Fixes #64)

### DIFF
--- a/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.psm1
+++ b/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String]
@@ -32,9 +34,9 @@ function Get-TargetResource
 
     $cas = GetClientAccessServer @PSBoundParameters
 
-    if ($cas -ne $null)
+    if ($null -ne $cas)
     {
-        if ($cas.AutoDiscoverSiteScope -ne $null)
+        if ($null -ne $cas.AutoDiscoverSiteScope)
         {
             $sites = $cas.AutoDiscoverSiteScope.ToArray()
         }
@@ -52,6 +54,7 @@ function Get-TargetResource
 
 function Set-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     param
     (
@@ -61,6 +64,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String]
@@ -100,6 +104,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -110,6 +115,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String]
@@ -132,7 +138,7 @@ function Test-TargetResource
 
     $cas = GetClientAccessServer @PSBoundParameters
 
-    if ($cas -eq $null)
+    if ($null -eq $cas)
     {
         return $false
     }
@@ -164,6 +170,7 @@ function GetClientAccessServer
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String]

--- a/README.md
+++ b/README.md
@@ -805,6 +805,8 @@ Defaults to $false.
 
 ### Unreleased
 
+* Fixed PSSA issues in MSFT_xExchClientAccessServer
+
 ### 1.7.0.0
 
 * xExchOwaVirtualDirectory


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchClientAccessServer.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/102)
<!-- Reviewable:end -->
