### PR TITLE
Fix PSSA Issues in MSFT_xExchEcpVirtualDirectory (Fixes #68)

### DIFF
--- a/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -53,7 +55,7 @@ function Get-TargetResource
 
     $EcpVdir = GetEcpVirtualDirectory @PSBoundParameters
 
-    if ($EcpVdir -ne $null)
+    if ($null -ne $EcpVdir)
     {
         $returnValue = @{
             DigestAuthentication = $EcpVdir.DigestAuthentication
@@ -84,6 +86,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -147,6 +150,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -157,6 +161,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -203,7 +208,7 @@ function Test-TargetResource
     
     $EcpVdir = GetEcpVirtualDirectory @PSBoundParameters
 
-    if ($EcpVdir -eq $null)
+    if ($null -eq $EcpVdir)
     {
         return $false
     }
@@ -265,6 +270,7 @@ function GetEcpVirtualDirectory
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchEcpVirtualDirectory
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchEcpVirtualDirectory.
This fixes #68.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/106)
<!-- Reviewable:end -->
