### PR TITLE
Fix PSSA Issues in MSFT_xExchMapiVirtualDirectory (Fixes #80)

### DIFF
--- a/DSCResources/MSFT_xExchMapiVirtualDirectory/MSFT_xExchMapiVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchMapiVirtualDirectory/MSFT_xExchMapiVirtualDirectory.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -39,7 +41,7 @@ function Get-TargetResource
 
     $vdir = GetMapiVirtualDirectory @PSBoundParameters
 
-    if ($vdir -ne $null)
+    if ($null -ne $vdir)
     {
         $returnValue = @{
             Identity = $Identity
@@ -64,6 +66,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -113,6 +116,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -123,6 +127,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -152,7 +157,7 @@ function Test-TargetResource
 
     $vdir = GetMapiVirtualDirectory @PSBoundParameters
 
-    if ($vdir -eq $null)
+    if ($null -eq $vdir)
     {
         return $false
     }
@@ -189,6 +194,7 @@ function GetMapiVirtualDirectory
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchMapiVirtualDirectory
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchMapiVirtualDirectory.
This fixes #80.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/111)
<!-- Reviewable:end -->
