### PR TITLE
Fix PSSA Issues in MSFT_xExchOabVirtualDirectory (Fixes #81)

### DIFF
--- a/DSCResources/MSFT_xExchOabVirtualDirectory/MSFT_xExchOabVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchOabVirtualDirectory/MSFT_xExchOabVirtualDirectory.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String[]]
@@ -62,16 +64,16 @@ function Get-TargetResource
 
     $vdir = Get-OabVirtualDirectory @PSBoundParameters
 
-    if ($vdir -ne $null)
+    if ($null -ne $vdir)
     {        
         RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToKeep "DomainController"
 
         #Get all OAB's which this VDir distributes for, and add their names to an array
-        $oabs = Get-OfflineAddressBook @PSBoundParameters | where {$_.VirtualDirectories -like "*$($Identity)*"}
+        $oabs = Get-OfflineAddressBook @PSBoundParameters | Where-Object {$_.VirtualDirectories -like "*$($Identity)*"}
 
         [string[]]$oabNames = @()
 
-        if ($oabs -ne $null)
+        if ($null -ne $oabs)
         {
             foreach ($oab in $oabs)
             {
@@ -109,6 +111,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String[]]
@@ -195,6 +198,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -205,6 +209,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String[]]
@@ -252,7 +257,7 @@ function Test-TargetResource
 
     $vdir = Get-TargetResource @PSBoundParameters
 
-    if ($vdir -eq $null)
+    if ($null -eq $vdir)
     {
         return $false
     }
@@ -324,6 +329,7 @@ function AddOabDistributionPoint
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.String[]]
@@ -375,7 +381,7 @@ function AddOabDistributionPoint
     AddParameters -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{"Identity" = $TargetOabName}
     RemoveParameters -PSBoundParametersIn $PSBoundParameters -ParamsToKeep "Identity","DomainController"
 
-    $oab = Get-OfflineAddressBook @PSBoundParameters    if ($oab -ne $null)    {        #Assemble the list of existing Virtual Directories        [string[]]$allVdirs = @()              foreach ($vdir in $oab.VirtualDirectories)        {            $oabServer = ServerFromOABVdirDN -OabVdirDN $vdir.DistinguishedName                        [string]$entry = $oabServer + "\" + $vdir.Name                        $allVdirs += $entry        }        #Add desired vdir to existing list        $allVdirs += $vdirIdentity
+    $oab = Get-OfflineAddressBook @PSBoundParameters    if ($null -ne $oab)    {        #Assemble the list of existing Virtual Directories        [string[]]$allVdirs = @()              foreach ($vdir in $oab.VirtualDirectories)        {            $oabServer = ServerFromOABVdirDN -OabVdirDN $vdir.DistinguishedName                        [string]$entry = $oabServer + "\" + $vdir.Name                        $allVdirs += $entry        }        #Add desired vdir to existing list        $allVdirs += $vdirIdentity
 
         #Set back to the OAB
         Set-OfflineAddressBook @PSBoundParameters -VirtualDirectories $allVdirs

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchOabVirtualDirectory
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchOabVirtualDirectory.
This fixes #81.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/112)
<!-- Reviewable:end -->
