### PR TITLE
Fix PSSA Issues in MSFT_xExchOutlookAnywhere (Fixes #82)

### DIFF
--- a/DSCResources/MSFT_xExchOutlookAnywhere/MSFT_xExchOutlookAnywhere.psm1
+++ b/DSCResources/MSFT_xExchOutlookAnywhere/MSFT_xExchOutlookAnywhere.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -65,7 +67,7 @@ function Get-TargetResource
 
     $RpcVdir = GetOutlookAnywhere @PSBoundParameters
 
-    if ($RpcVdir -ne $null)
+    if ($null -ne $RpcVdir)
     {
         $returnValue = @{
             Identity = $Identity
@@ -98,6 +100,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -174,6 +177,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -184,6 +188,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -242,7 +247,7 @@ function Test-TargetResource
 
     $RpcVdir = GetOutlookAnywhere @PSBoundParameters
 
-    if ($RpcVdir -eq $null)
+    if ($null -eq $RpcVdir)
     {
         return $false
     }
@@ -315,6 +320,7 @@ function GetOutlookAnywhere
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchOutlookAnywhere
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchOutlookAnywhere.
This fixes #82.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/113)
<!-- Reviewable:end -->
