### PR TITLE
Fix PSSA Issues in MSFT_xExchOwaVirtualDirectory (Fixes #83)

### DIFF
--- a/DSCResources/MSFT_xExchOwaVirtualDirectory/MSFT_xExchOwaVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchOwaVirtualDirectory/MSFT_xExchOwaVirtualDirectory.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -82,7 +84,7 @@ function Get-TargetResource
 
     $OwaVdir = GetOwaVirtualDirectory @PSBoundParameters
 
-    if ($OwaVdir -ne $null)
+    if ($null -ne $OwaVdir)
     {
         $returnValue = @{
             Identity = $Identity
@@ -120,6 +122,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -212,6 +215,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -222,6 +226,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -297,7 +302,7 @@ function Test-TargetResource
   
     $OwaVdir = GetOwaVirtualDirectory @PSBoundParameters
 
-    if ($OwaVdir -eq $null)
+    if ($null -eq $OwaVdir)
     {
         return $false
     }
@@ -404,6 +409,7 @@ function GetOwaVirtualDirectory
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchOwaVirtualDirectory
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchOwaVirtualDirectory.
This fixes #83.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/114)
<!-- Reviewable:end -->
