### PR TITLE
Fix PSSA Issues in MSFT_xExchPopSettings (Fixes #84)

### DIFF
--- a/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.psm1
+++ b/DSCResources/MSFT_xExchPopSettings/MSFT_xExchPopSettings.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -39,7 +41,7 @@ function Get-TargetResource
 
     $pop = GetPopSettings @PSBoundParameters
 
-    if ($pop -ne $null)
+    if ($null -ne $pop)
     {
         $returnValue = @{
             Server = $Identity
@@ -64,6 +66,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -110,6 +113,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -120,6 +124,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -151,7 +156,7 @@ function Test-TargetResource
 
     $pop = GetPopSettings @PSBoundParameters
 
-    if ($pop -eq $null)
+    if ($null -eq $pop)
     {
         return $false
     }
@@ -187,6 +192,7 @@ function GetPopSettings
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchPopSettings
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchPopSettings.
This fixes #84.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/115)
<!-- Reviewable:end -->
