### PR TITLE
Fix PSSA Issues in MSFT_xExchPowershellVirtualDirectory (Fixes #85)

### DIFF
--- a/DSCResources/MSFT_xExchPowershellVirtualDirectory/MSFT_xExchPowerShellVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchPowershellVirtualDirectory/MSFT_xExchPowerShellVirtualDirectory.psm1
@@ -1,5 +1,6 @@
 function Get-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -10,6 +11,7 @@ function Get-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -47,7 +49,7 @@ function Get-TargetResource
 
     $vdir = GetPowerShellVirtualDirectory @PSBoundParameters
 
-    if ($vdir -ne $null)
+    if ($null -ne $vdir)
     {
         $returnValue = @{
             Identity = $Identity
@@ -75,6 +77,7 @@ function Set-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -135,6 +138,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -145,6 +149,7 @@ function Test-TargetResource
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]
@@ -182,7 +187,7 @@ function Test-TargetResource
 
     $vdir = GetPowerShellVirtualDirectory @PSBoundParameters
 
-    if ($vdir -eq $null)
+    if ($null -eq $vdir)
     {
         return $false
     }
@@ -233,6 +238,7 @@ function GetPowerShellVirtualDirectory
 
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
         $Credential,
 
         [System.Boolean]

--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ Defaults to $false.
     * MSFT_xExchWaitForMailboxDatabase
     * MSFT_xExchWebServicesVirtualDirectory
     * MSFT_xExchExchangeCertificate
+    * MSFT_xExchPowershellVirtualDirectory
 
 ### 1.7.0.0
 


### PR DESCRIPTION
Fixing the PSSA Issues in MSFT_xExchPowershellVirtualDirectory.
This fixes #85.

Running Invoke-ScriptAnalyzer with the following rules excluded no longer has any output:
PSUseShouldProcessForStateChangingFunctions
PSDSCDscTestsPresent
PSDSCDscExamplesPresent

These rules have been approved to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/116)
<!-- Reviewable:end -->
