### PR TITLE
Adding PSSA rule supression for test.

### DIFF
--- a/Test/MSFT_xExchExchangeCertificate.Integration.Tests.ps1
+++ b/Test/MSFT_xExchExchangeCertificate.Integration.Tests.ps1
@@ -1,5 +1,8 @@
 ###NOTE: This test module requires use of credentials. The first run through of the tests will prompt for credentials from the logged on user.
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param ()
+
 Import-Module $PSScriptRoot\..\DSCResources\MSFT_xExchExchangeCertificate\MSFT_xExchExchangeCertificate.psm1
 Import-Module $PSScriptRoot\..\Misc\xExchangeCommon.psm1 -Verbose:0
 Import-Module $PSScriptRoot\xExchange.Tests.Common.psm1 -Verbose:0


### PR DESCRIPTION
This is a hotfix needed for release.
PSSA rules are allowed to be suppressed in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/122)
<!-- Reviewable:end -->
