### PR TITLE
Fix malformed dash/hyphen characters

### DIFF
--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.psm1
@@ -888,7 +888,7 @@ function PrepareVolume
 
         Start-Sleep -Seconds 15
 
-        Get-Partition -DiskNumber $DiskNumber -PartitionNumber 2| Format-Volume –AllocationUnitSize $UnitSizeBytes –FileSystem REFS –NewFileSystemLabel $Label –SetIntegrityStreams:$false -Confirm:$false
+        Get-Partition -DiskNumber $DiskNumber -PartitionNumber 2| Format-Volume -AllocationUnitSize $UnitSizeBytes -FileSystem REFS -NewFileSystemLabel $Label -SetIntegrityStreams:$false -Confirm:$false
         Add-PartitionAccessPath -DiskNumber $DiskNumber -PartitionNumber 2 -AccessPath $Folder -PassThru | Set-Partition -NoDefaultDriveLetter $true
     }
 }

--- a/README.md
+++ b/README.md
@@ -842,13 +842,12 @@ Defaults to $false.
 ## Versions
 
 ### Unreleased
-xExchAutoMountPoint: Fix malformed dash/hyphen characters
+* xExchAutoMountPoint: Fix malformed dash/hyphen characters
 
 ### 1.9.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * Added xExchMailboxTransportService resource
 * xExchMailboxServer: Added WacDiscoveryEndpoint parameter
-* xExchAutoMountPoint: Fix malformed dash/hyphen characters
 
 ### 1.8.0.0
 

--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ xExchAutoMountPoint: Fix malformed dash/hyphen characters
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * Added xExchMailboxTransportService resource
 * xExchMailboxServer: Added WacDiscoveryEndpoint parameter
+* xExchAutoMountPoint: Fix malformed dash/hyphen characters
 
 ### 1.8.0.0
 

--- a/README.md
+++ b/README.md
@@ -842,6 +842,7 @@ Defaults to $false.
 ## Versions
 
 ### Unreleased
+xExchAutoMountPoint: Fix malformed dash/hyphen characters
 
 ### 1.9.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.


### PR DESCRIPTION
Noticed that I was getting errors when trying to use MSFT_xExchAutoMountPoint with REFS formatting.  Found that some dash/hyphen characters were displaying as â€“ in certain editors.  Issue described in this post https://markmcb.com/2011/11/07/replacing-ae%E2%80%9C-ae%E2%84%A2-aeoe-etc-with-utf-8-characters-in-ruby-on-rails/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/131)
<!-- Reviewable:end -->
