### PR TITLE
Fix issue where ClientCertAuth parameter set to "Allowed" instead of "Accepted"

### DIFF
--- a/DSCResources/MSFT_xExchActiveSyncVirtualDirectory/MSFT_xExchActiveSyncVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchActiveSyncVirtualDirectory/MSFT_xExchActiveSyncVirtualDirectory.psm1
@@ -29,7 +29,7 @@ function Get-TargetResource
         [System.Boolean]
         $BasicAuthEnabled,
 
-        [ValidateSet("Ignore", "Allowed", "Required")]
+        [ValidateSet("Ignore", "Accepted", "Required")]
         [System.String]
         $ClientCertAuth,
 
@@ -111,7 +111,7 @@ function Set-TargetResource
         [System.Boolean]
         $BasicAuthEnabled,
 
-        [ValidateSet("Ignore", "Allowed", "Required")]
+        [ValidateSet("Ignore", "Accepted", "Required")]
         [System.String]
         $ClientCertAuth,
 
@@ -226,7 +226,7 @@ function Test-TargetResource
         [System.Boolean]
         $BasicAuthEnabled,
 
-        [ValidateSet("Ignore", "Allowed", "Required")]
+        [ValidateSet("Ignore", "Accepted", "Required")]
         [System.String]
         $ClientCertAuth,
 
@@ -366,7 +366,7 @@ function Get-ActiveSyncVirtualDirectoryWithCorrectParams
         [System.Boolean]
         $BasicAuthEnabled,
 
-        [ValidateSet("Ignore", "Allowed", "Required")]
+        [ValidateSet("Ignore", "Accepted", "Required")]
         [System.String]
         $ClientCertAuth,
 

--- a/DSCResources/MSFT_xExchActiveSyncVirtualDirectory/MSFT_xExchActiveSyncVirtualDirectory.schema.mof
+++ b/DSCResources/MSFT_xExchActiveSyncVirtualDirectory/MSFT_xExchActiveSyncVirtualDirectory.schema.mof
@@ -12,7 +12,7 @@ class MSFT_xExchActiveSyncVirtualdirectory : OMI_BaseResource
     //Remaining properties correspond directly to Set-ActiveSyncVirtualDirectory parameters
     //http://technet.microsoft.com/en-us/library/bb123679(v=exchg.150).aspx
     [Write] Boolean BasicAuthEnabled;
-    [Write, ValueMap{"Ignore","Allowed","Required"}, Values{"Ignore","Allowed","Required"}] String ClientCertAuth;
+    [Write, ValueMap{"Ignore","Accepted","Required"}, Values{"Ignore","Accepted","Required"}] String ClientCertAuth;
     [Write] Boolean CompressionEnabled;
     [Write] String DomainController;
     [Write] String ExternalAuthenticationMethods[];

--- a/README.md
+++ b/README.md
@@ -842,6 +842,7 @@ Defaults to $false.
 ## Versions
 
 ### Unreleased
+* xExchActiveSyncVirtualDirectory: Fix issue where ClientCertAuth parameter set to "Allowed" instead of "Accepted"
 
 ### 1.10.0.0
 * xExchAutoMountPoint: Fix malformed dash/hyphen characters


### PR DESCRIPTION
Found an issue in xExchActiveSyncVirtualDirectory where attempting to use the option "Accepted" for ClientCertAuth was not allowed, options were forced to Ignore, **Allowed**, Required.  When using "Allowed" the config would compile but not apply as valid options for ClientCertAuth are Ignore, **Accepted**, Required. Updated xExchActiveSyncVirtualDirectory to that effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/135)
<!-- Reviewable:end -->
