### PR TITLE
Fix array comparison issues by removing check for if array is null

### DIFF
--- a/Misc/xExchangeCommon.psm1
+++ b/Misc/xExchangeCommon.psm1
@@ -89,7 +89,7 @@ function GetRemoteExchangeSession
         $oldVerbose = $VerbosePreference
         $VerbosePreference = "SilentlyContinue"
 
-        if ($null -ne $CommandsToLoad -and $CommandsToLoad.Count -gt 0)
+        if ($CommandsToLoad.Count -gt 0)
         {
             $moduleInfo = Import-PSSession $Session -WarningAction SilentlyContinue -DisableNameChecking -AllowClobber -CommandName $CommandsToLoad -Verbose:0
         }
@@ -398,14 +398,11 @@ function StringArrayToLower
 {
     param([string[]]$Array)
     
-    if ($null -ne $Array)
+    for ($i = 0; $i -lt $Array.Count; $i++)
     {
-        for ($i = 0; $i -lt $Array.Count; $i++)
+        if (!([string]::IsNullOrEmpty($Array[$i])))
         {
-            if (!([string]::IsNullOrEmpty($Array[$i])))
-            {
-                $Array[$i] = $Array[$i].ToLower()
-            }
+            $Array[$i] = $Array[$i].ToLower()
         }
     }
 
@@ -419,11 +416,11 @@ function CompareArrayContents
 
     $hasSameContents = $true
 
-    if (($null -eq $Array1 -and $null -ne $Array2) -or ($null -ne $Array1 -and $null -eq $Array2) -or ($Array1.Length -ne $Array2.Length))
+    if ($Array1.Length -ne $Array2.Length)
     {
         $hasSameContents = $false
     }
-    elseif ($null -ne $Array1 -and $null -ne $Array2)
+    elseif ($Array1.Count -gt 0 -and $Array2.Count -gt 0)
     {
         if ($IgnoreCase -eq $true)
         {
@@ -451,9 +448,9 @@ function Array2ContainsArray1Contents
 
     $hasContents = $true
 
-    if ($null -eq $Array1 -or $Array1.Length -eq 0) #Do nothing, as Array2 at a minimum contains nothing    
+    if ($Array1.Length -eq 0) #Do nothing, as Array2 at a minimum contains nothing    
     {} 
-    elseif ($null -eq $Array2 -or $Array2.Length -eq 0) #Array2 is empty and Array1 is not. Return false
+    elseif ($Array2.Length -eq 0) #Array2 is empty and Array1 is not. Return false
     {
         $hasContents = $false
     }
@@ -503,7 +500,7 @@ function RemoveParameters
 {
     param($PSBoundParametersIn, [string[]]$ParamsToKeep, [string[]]$ParamsToRemove)
 
-    if ($null -ne $ParamsToKeep -and $ParamsToKeep.Count -gt 0)
+    if ($ParamsToKeep.Count -gt 0)
     {
         [string[]]$ParamsToRemove = @()
 
@@ -518,7 +515,7 @@ function RemoveParameters
         }
     }
 
-    if ($null -ne $ParamsToRemove -and $ParamsToRemove.Count -gt 0)
+    if ($ParamsToRemove.Count -gt 0)
     {
         foreach ($param in $ParamsToRemove)
         {
@@ -679,7 +676,7 @@ function LogFunctionEntry
 
     $callingFunction = (Get-PSCallStack)[1].FunctionName
 
-    if ($null -ne $Parameters -and $Parameters.Count -gt 0)
+    if ($Parameters.Count -gt 0)
     {
         $parametersString = ""
 
@@ -809,7 +806,7 @@ function NotePreviousError
 {
     $Global:previousError = $null
 
-    if ($null -ne $Global:error -and $Global:error.Count -gt 0)
+    if ($Global:error.Count -gt 0)
     {
         $Global:previousError = $Global:error[0]
     }    
@@ -821,7 +818,7 @@ function ThrowIfNewErrorsEncountered
     param([string]$CmdletBeingRun, $VerbosePreference)
 
     #Throw an exception if errors were encountered
-    if ($null -ne $Global:error -and $Global:error.Count -gt 0 -and $Global:previousError -ne $Global:error[0])
+    if ($Global:error.Count -gt 0 -and $Global:previousError -ne $Global:error[0])
     {
         [string]$errorMsg = "Failed to run $($CmdletBeingRun) with: " + $Global:error[0]
         Write-Error $errorMsg

--- a/README.md
+++ b/README.md
@@ -850,6 +850,7 @@ Defaults to $false.
 * Fix PSAvoidUsingEmptyCatchBlock issues from PSScriptAnalyzer
 * Fix PSUsePSCredentialType issues from PSScriptAnalyzer
 * Fix erroneous PSDSCDscTestsPresent issues from PSScriptAnalyzer for modules that do actually have tests in the root Tests folder
+* Fix array comparison issues by removing check for if array is null
 
 ### 1.11.0.0
 * xExchActiveSyncVirtualDirectory: Fix issue where ClientCertAuth parameter set to "Allowed" instead of "Accepted"

--- a/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
+++ b/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
@@ -51,7 +51,7 @@ if ($exchangeInstalled)
         $expectedGetResults = @{}
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set site scope to multi value" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.AutoDiscoverSiteScope -GetResultParameterName "AutoDiscoverSiteScope" -ContextLabel "Verify AutoDiscoverSiteScope" -ItLabel "AutoDiscoverSiteScope should contain two values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.AutoDiscoverSiteScope -GetResultParameterName "AutoDiscoverSiteScope" -ContextLabel "Verify AutoDiscoverSiteScope" -ItLabel "AutoDiscoverSiteScope should contain two values"
 
 
         #Now set the site scope to $null
@@ -59,7 +59,7 @@ if ($exchangeInstalled)
         $expectedGetResults = @{}
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set site scope to null" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.AutoDiscoverSiteScope -GetResultParameterName "AutoDiscoverSiteScope" -ContextLabel "Verify AutoDiscoverSiteScope" -ItLabel "AutoDiscoverSiteScope should be empty"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.AutoDiscoverSiteScope -GetResultParameterName "AutoDiscoverSiteScope" -ContextLabel "Verify AutoDiscoverSiteScope" -ItLabel "AutoDiscoverSiteScope should be empty"
     }
 }
 else

--- a/Test/MSFT_xExchDatabaseAvailabilityGroup.Integration.Tests.ps1
+++ b/Test/MSFT_xExchDatabaseAvailabilityGroup.Integration.Tests.ps1
@@ -192,7 +192,7 @@ if ($null -ne $adModule)
                 }
 
                 Test-TargetResourceFunctionality -Params $dagTestParams -ContextLabel "Create the test DAG" -ExpectedGetResults $dagExpectedGetResults
-                Test-ContentsOfArray -TestParams $dagTestParams -DesiredArrayContents $dagTestParams.DatabaseAvailabilityGroupIpAddresses -GetResultParameterName "DatabaseAvailabilityGroupIpAddresses" -ContextLabel "Verify DatabaseAvailabilityGroupIpAddresses" -ItLabel "DatabaseAvailabilityGroupIpAddresses should contain two values"
+                Test-ArrayContentsEqual -TestParams $dagTestParams -DesiredArrayContents $dagTestParams.DatabaseAvailabilityGroupIpAddresses -GetResultParameterName "DatabaseAvailabilityGroupIpAddresses" -ContextLabel "Verify DatabaseAvailabilityGroupIpAddresses" -ItLabel "DatabaseAvailabilityGroupIpAddresses should contain two values"
 
 
                 #Add this server as a DAG member
@@ -237,7 +237,7 @@ if ($null -ne $adModule)
                 $dagExpectedGetResults.DatacenterActivationMode = "DagOnly"
 
                 Test-TargetResourceFunctionality -Params $dagTestParams -ContextLabel "Set remaining props on the test DAG" -ExpectedGetResults $dagExpectedGetResults
-                Test-ContentsOfArray -TestParams $dagTestParams -DesiredArrayContents $dagTestParams.DatabaseAvailabilityGroupIpAddresses -GetResultParameterName "DatabaseAvailabilityGroupIpAddresses" -ContextLabel "Verify DatabaseAvailabilityGroupIpAddresses" -ItLabel "DatabaseAvailabilityGroupIpAddresses should contain two values"
+                Test-ArrayContentsEqual -TestParams $dagTestParams -DesiredArrayContents $dagTestParams.DatabaseAvailabilityGroupIpAddresses -GetResultParameterName "DatabaseAvailabilityGroupIpAddresses" -ContextLabel "Verify DatabaseAvailabilityGroupIpAddresses" -ItLabel "DatabaseAvailabilityGroupIpAddresses should contain two values"
 
 
                 #Create a new DAG database

--- a/Test/MSFT_xExchImapSettings.Integration.Tests.ps1
+++ b/Test/MSFT_xExchImapSettings.Integration.Tests.ps1
@@ -36,7 +36,7 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should contain a value"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should contain a value"
 
         $testParams.LoginType = "SecureLogin"
         $testParams.ExternalConnectionSettings = @()
@@ -45,7 +45,7 @@ if ($exchangeInstalled)
         $expectedGetResults.X509CertificateName = ""
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Change some parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should be empty"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should be empty"
     }
 }
 else

--- a/Test/MSFT_xExchMapiVirtualDirectory.Integration.Tests.ps1
+++ b/Test/MSFT_xExchMapiVirtualDirectory.Integration.Tests.ps1
@@ -37,7 +37,7 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
 
         $testParams = @{
             Identity =  "$($env:COMPUTERNAME)\mapi (Default Web Site)"
@@ -54,7 +54,7 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Try with different values" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
     }
 }
 else

--- a/Test/MSFT_xExchOabVirtualDirectory.Integration.Tests.ps1
+++ b/Test/MSFT_xExchOabVirtualDirectory.Integration.Tests.ps1
@@ -49,9 +49,9 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionFlags -GetResultParameterName "ExtendedProtectionFlags" -ContextLabel "Verify ExtendedProtectionFlags" -ItLabel "ExtendedProtectionFlags should contain two values"
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionSPNList -GetResultParameterName "ExtendedProtectionSPNList" -ContextLabel "Verify ExtendedProtectionSPNList" -ItLabel "ExtendedProtectionSPNList should be empty"
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.OABsToDistribute -GetResultParameterName "OABsToDistribute" -ContextLabel "Verify OABsToDistribute" -ItLabel "OABsToDistribute contains an OAB"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionFlags -GetResultParameterName "ExtendedProtectionFlags" -ContextLabel "Verify ExtendedProtectionFlags" -ItLabel "ExtendedProtectionFlags should contain two values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionSPNList -GetResultParameterName "ExtendedProtectionSPNList" -ContextLabel "Verify ExtendedProtectionSPNList" -ItLabel "ExtendedProtectionSPNList should be empty"
+        Test-Array2ContainsArray1 -TestParams $testParams -DesiredArrayContents $testParams.OABsToDistribute -GetResultParameterName "OABsToDistribute" -ContextLabel "Verify OABsToDistribute" -ItLabel "OABsToDistribute contains an OAB"
     }
 }
 else

--- a/Test/MSFT_xExchOutlookAnywhere.Integration.Tests.ps1
+++ b/Test/MSFT_xExchOutlookAnywhere.Integration.Tests.ps1
@@ -51,9 +51,9 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionFlags -GetResultParameterName "ExtendedProtectionFlags" -ContextLabel "Verify ExtendedProtectionFlags" -ItLabel "ExtendedProtectionFlags should contain two values"
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionSPNList -GetResultParameterName "ExtendedProtectionSPNList" -ContextLabel "Verify ExtendedProtectionSPNList" -ItLabel "ExtendedProtectionSPNList should be empty"
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionFlags -GetResultParameterName "ExtendedProtectionFlags" -ContextLabel "Verify ExtendedProtectionFlags" -ItLabel "ExtendedProtectionFlags should contain two values"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExtendedProtectionSPNList -GetResultParameterName "ExtendedProtectionSPNList" -ContextLabel "Verify ExtendedProtectionSPNList" -ItLabel "ExtendedProtectionSPNList should be empty"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.IISAuthenticationMethods -GetResultParameterName "IISAuthenticationMethods" -ContextLabel "Verify IISAuthenticationMethods" -ItLabel "IISAuthenticationMethods should contain three values"
     }
 }
 else

--- a/Test/MSFT_xExchPopSettings.Integration.Tests.ps1
+++ b/Test/MSFT_xExchPopSettings.Integration.Tests.ps1
@@ -36,7 +36,7 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should contain a value"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should contain a value"
 
         $testParams.LoginType = "SecureLogin"
         $testParams.ExternalConnectionSettings = @()
@@ -45,7 +45,7 @@ if ($exchangeInstalled)
         $expectedGetResults.X509CertificateName = ""
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Change some parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should be empty"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.ExternalConnectionSettings -GetResultParameterName "ExternalConnectionSettings" -ContextLabel "Verify ExternalConnectionSettings" -ItLabel "ExternalConnectionSettings should be empty"
     }
 }
 else

--- a/Test/MSFT_xExchUMService.Integration.Tests.ps1
+++ b/Test/MSFT_xExchUMService.Integration.Tests.ps1
@@ -34,7 +34,7 @@ if ($exchangeInstalled)
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set standard parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.DialPlans -GetResultParameterName "DialPlans" -ContextLabel "Verify DialPlans" -ItLabel "DialPlans should be empty"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.DialPlans -GetResultParameterName "DialPlans" -ContextLabel "Verify DialPlans" -ItLabel "DialPlans should be empty"
 
         $testParams.UMStartupMode = "Dual"
         $testParams.DialPlans = @($Global:UMDialPlan)
@@ -42,7 +42,7 @@ if ($exchangeInstalled)
         $expectedGetResults.DialPlans = @($Global:UMDialPlan)
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Change some parameters" -ExpectedGetResults $expectedGetResults
-        Test-ContentsOfArray -TestParams $testParams -DesiredArrayContents $testParams.DialPlans -GetResultParameterName "DialPlans" -ContextLabel "Verify DialPlans" -ItLabel "DialPlans should contain a value"
+        Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.DialPlans -GetResultParameterName "DialPlans" -ContextLabel "Verify DialPlans" -ItLabel "DialPlans should contain a value"
     }
 }
 else

--- a/Test/xExchange.Tests.Common.psm1
+++ b/Test/xExchange.Tests.Common.psm1
@@ -44,7 +44,7 @@ function Test-TargetResourceFunctionality
     }
 }
 
-function Test-ContentsOfArray
+function Test-ArrayContentsEqual
 {
     [CmdletBinding()]
     param([Hashtable]$TestParams, [string[]]$DesiredArrayContents, [string]$GetResultParameterName, [string]$ContextLabel, [string]$ItLabel)
@@ -57,5 +57,21 @@ function Test-ContentsOfArray
         }
     }
 }
+
+function Test-Array2ContainsArray1
+{
+    [CmdletBinding()]
+    param([Hashtable]$TestParams, [string[]]$DesiredArrayContents, [string]$GetResultParameterName, [string]$ContextLabel, [string]$ItLabel)
+
+    Context $ContextLabel {
+        [Hashtable]$getResult = Get-TargetResource @TestParams
+
+        It $ItLabel {
+            Array2ContainsArray1Contents -Array1 $DesiredArrayContents -Array2 $getResult."$($GetResultParameterName)" -IgnoreCase | Should Be $true
+        }
+    }
+}
+
+Array2ContainsArray1Contents
 
 Export-ModuleMember -Function *


### PR DESCRIPTION
Discovered some array comparison issues after running the full set of Pester tests against the latest Dev code base. Specifically found issues with array checking in the MSFT_xExchOabVirtualDirectory and MSFT_xExchUMService resources. Changed most of the checks in xExchangeCommon.psm1 to not check if array is $null, as in PS4 (the minimum required PowerShell version for this module), $null.Count resolves to 0. As such, we can just check the .Count property and assume it will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/150)
<!-- Reviewable:end -->
