### PR TITLE
Added check to ensure Failover-Clustering role is installed before adding server to DAG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,8 @@ Defaults to $false.
 
 ### Unreleased
 
+* xExchDatabaseAvailabilityGroupMember: Added check to ensure Failover-Clustering role is installed before adding server to DAG.
+
 ### 1.14.0.0
 
 * xExchDatabaseAvailabilityGroup: Added parameter AutoDagAutoRedistributeEnabled,PreferenceMoveFrequency


### PR DESCRIPTION
Added check to ensure Failover-Clustering role is installed before adding server to DAG. This is a fix for issue https://github.com/PowerShell/xExchange/issues/154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/183)
<!-- Reviewable:end -->
