### PR TITLE
Update DAG and OAB Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ Defaults to $false.
 * xExchInstall: Remove parameter '-AllowImmediateReboot $AllowImmediateReboot' when calling CheckWSManConfig.
 * xExchOutlookAnywhere: Add test for ExternalClientAuthenticationMethod.
 * Test: Update OAB and UMService tests to create test OAB and UMDialPlans, respectively.
+* Test: Update MailboxDatabase tests to use test OAB. Update DAG to skip DAG tests and write error if cluster feature not installed.
 
 ### 1.14.0.0
 

--- a/Test/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
+++ b/Test/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
@@ -45,6 +45,9 @@ if ($exchangeInstalled)
 
     PrepTestDB -TestDBName $TestDBName
 
+    #Get the test OAB
+    $testOabName = Get-TestOfflineAddressBook -ShellCredentials $Global:ShellCredentials
+
     Describe "Test Creating a DB and Setting Properties with xExchMailboxDatabase" {
         $testParams = @{
             Name = $TestDBName
@@ -65,7 +68,7 @@ if ($exchangeInstalled)
             IsSuspendedFromProvisioning = $false
             MailboxRetention = "30.00:00:00"
             MountAtStartup = $true
-            OfflineAddressBook = "Default Offline Address Book (Ex2013)"
+            OfflineAddressBook = $testOabName
             RetainDeletedItemsUntilBackup = $false
             IssueWarningQuota = "27 MB"
             ProhibitSendQuota = "1GB"
@@ -91,7 +94,7 @@ if ($exchangeInstalled)
             IsSuspendedFromProvisioning = $false
             MailboxRetention = "30.00:00:00"
             MountAtStartup = $true
-            OfflineAddressBook = "\Default Offline Address Book (Ex2013)"
+            OfflineAddressBook = "\$testOabName"
             RetainDeletedItemsUntilBackup = $false
             IssueWarningQuota = "27 MB"
             ProhibitSendQuota = "1GB"
@@ -121,7 +124,7 @@ if ($exchangeInstalled)
             IsSuspendedFromProvisioning = $true
             MailboxRetention = "31.00:00:00"
             MountAtStartup = $false
-            OfflineAddressBook = "Default Offline Address Book (Ex2013)"
+            OfflineAddressBook = $testOabName
             RetainDeletedItemsUntilBackup = $true
             IssueWarningQuota = "28 MB"
             ProhibitSendQuota = "2GB"
@@ -147,7 +150,7 @@ if ($exchangeInstalled)
             IsSuspendedFromProvisioning = $true
             MailboxRetention = "31.00:00:00"
             MountAtStartup = $false
-            OfflineAddressBook = "\Default Offline Address Book (Ex2013)"
+            OfflineAddressBook = "\$testOabName"
             RetainDeletedItemsUntilBackup = $true
             IssueWarningQuota = "28 MB"
             ProhibitSendQuota = "2GB"

--- a/Test/MSFT_xExchOabVirtualDirectory.Integration.Tests.ps1
+++ b/Test/MSFT_xExchOabVirtualDirectory.Integration.Tests.ps1
@@ -7,8 +7,6 @@ Import-Module $PSScriptRoot\xExchange.Tests.Common.psm1 -Verbose:0
 #Check if Exchange is installed on this machine. If not, we can't run tests
 [bool]$exchangeInstalled = IsSetupComplete
 
-$testOabName = "Offline Address Book (DSC Test)"
-
 if ($exchangeInstalled)
 {
     #Get required credentials to use for the test
@@ -23,20 +21,8 @@ if ($exchangeInstalled)
         $Global:ServerFqdn = [System.Net.Dns]::GetHostByName($env:COMPUTERNAME).HostName
     }
 
-    #Check if the test OAB exists, and if not, create it
-    GetRemoteExchangeSession -Credential $Global:ShellCredentials -CommandsToLoad "*-OfflineAddressBook"
-
-    if ($null -eq (Get-OfflineAddressBook -Identity $testOabName -ErrorAction SilentlyContinue))
-    {
-        Write-Verbose "Test OAB does not exist. Creating OAB with name '$testOabName'."
-
-        $testOab = New-OfflineAddressBook -Name $testOabName -AddressLists \
-
-        if ($null -eq $testOab)
-        {
-            throw "Failed to create test OAB."
-        }
-    }
+    #Get the test OAB
+    $testOabName = Get-TestOfflineAddressBook -ShellCredentials $Global:ShellCredentials
 
     Describe "Test Setting Properties with xExchOabVirtualDirectory" {
         $testParams = @{

--- a/Test/xExchange.Tests.Common.psm1
+++ b/Test/xExchange.Tests.Common.psm1
@@ -72,6 +72,30 @@ function Test-Array2ContainsArray1
     }
 }
 
-Array2ContainsArray1Contents
+#Creates a test OAB for DSC, or sees if it exists. If it is created or exists, return the name of the OAB.
+function Get-TestOfflineAddressBook
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param([PSCredential]$ShellCredentials)
+
+    $testOabName = "Offline Address Book (DSC Test)"
+
+    GetRemoteExchangeSession -Credential $ShellCredentials -CommandsToLoad "*-OfflineAddressBook"
+
+    if ($null -eq (Get-OfflineAddressBook -Identity $testOabName -ErrorAction SilentlyContinue))
+    {
+        Write-Verbose "Test OAB does not exist. Creating OAB with name '$testOabName'."
+
+        $testOab = New-OfflineAddressBook -Name $testOabName -AddressLists \
+
+        if ($null -eq $testOab)
+        {
+            throw "Failed to create test OAB."
+        }
+    }
+
+    return $testOabName
+}
 
 Export-ModuleMember -Function *


### PR DESCRIPTION
Update xExchMailboxDatabase tests to use test OAB. Update DAG tests to write an error, and skip DAG tests, if the failover clustering feature is not installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/188)
<!-- Reviewable:end -->
