### PR TITLE
Add Missing Parameters to Resources #159 MSFT_xExchClientAccessServer 

### DIFF
--- a/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
+++ b/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
@@ -10,7 +10,7 @@ class MSFT_xExchClientAccessServer : OMI_BaseResource
     [Write] String AutoDiscoverServiceInternalUri;
     [Write] String AutoDiscoverSiteScope[];
     [Write] String DomainController;
-    [EmbeddedInstance("MSFT_Credential")] String AlternateServiceAccountCredential;
+    [Write, EmbeddedInstance("MSFT_Credential")] String AlternateServiceAccountCredential;
     [Write] Boolean CleanUpInvalidAlternateServiceAccountCredentials;
     [Write] Boolean RemoveAlternateServiceAccountCredentials;
 };

--- a/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
+++ b/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
@@ -10,6 +10,9 @@ class MSFT_xExchClientAccessServer : OMI_BaseResource
     [Write] String AutoDiscoverServiceInternalUri;
     [Write] String AutoDiscoverSiteScope[];
     [Write] String DomainController;
+    [EmbeddedInstance("MSFT_Credential")] String AlternateServiceAccountCredential;
+    [Write] Boolean CleanUpInvalidAlternateServiceAccountCredentials;
+    [Write] Boolean RemoveAlternateServiceAccountCredentials;
 };
 
 

--- a/Misc/xExchangeCommon.psm1
+++ b/Misc/xExchangeCommon.psm1
@@ -649,6 +649,13 @@ function VerifySetting
                 $returnValue = $false
             }
         }
+        elseif ($Type -like "PSCredential")
+        {
+            if ((Compare-PSCredential -Cred1 $ActualValue -Cred2 $ExpectedValue ) -eq $false)
+            {
+                $returnValue = $false
+            }        
+        }
         else
         {
             throw "Type not found: $($Type)"
@@ -938,6 +945,47 @@ function CompareIPAddressesWithArray
         ReportBadSetting -SettingName $IPAddresses -ExpectedValue $ExpectedValue -ActualValue $IPAddress -VerbosePreference $VerbosePreference
     }
     return $returnValue
+}
+
+#Compares two give PSCredential
+function Compare-PSCredential
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param (
+        #[System.Management.Automation.PSCredential]
+        #[System.Management.Automation.Credential()]
+        $Cred1,
+
+        #[System.Management.Automation.PSCredential]
+        #[System.Management.Automation.Credential()]
+        $Cred2
+    )
+Begin {
+    $returnValue = $false
+    if ($null -ne $Cred1) {
+        $Cred1User = $Cred1.UserName
+        $Cred1Password = $Cred1.GetNetworkCredential().Password
+    }
+    if ($null -ne $Cred2) {
+        $Cred2User = $Cred2.UserName
+        $Cred2Password = $Cred2.GetNetworkCredential().Password
+    }
+}
+Process {
+    if (($Cred1User -ceq $Cred2User) -and ($Cred1Password -ceq $Cred2Password)){
+        Write-Verbose "Credentials match"
+        $returnValue = $true
+    }
+    else{
+        Write-Verbose "Credentials don't match"
+        Write-Verbose "Cred1:$($Cred1User) Cred2:$($Cred2User)"
+        Write-Verbose "Cred1:$($Cred1Password) Cred2:$($Cred2Password)"
+    }
+}
+End {
+    return $returnValue
+}
 }
 
 Export-ModuleMember -Function *

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Where no description is listed, properties correspond directly to [Set-ClientAcc
 * **AutoDiscoverServiceInternalUri**
 * **AutoDiscoverSiteScope**
 * **DomainController**
+* **AlternateServiceAccountCredential**
+* **CleanUpInvalidAlternateServiceAccountCredentials**
+* **RemoveAlternateServiceAccountCredentials**
 
 ### xExchDatabaseAvailabilityGroup
 

--- a/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
+++ b/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
@@ -66,6 +66,7 @@ if ($exchangeInstalled)
         if ($null -eq $Global:ASACredentials)
         {
             $UserASA = "Fabrikam\ASA"
+            $PWordASA = ConvertTo-SecureString -String 'Pa$$w0rd!' -AsPlainText -Force
             $Global:ASACredentials = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $UserASA, $PWordASA
         }
 

--- a/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
+++ b/Test/MSFT_xExchClientAccessServer.Integration.Tests.ps1
@@ -60,6 +60,30 @@ if ($exchangeInstalled)
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set site scope to null" -ExpectedGetResults $expectedGetResults
         Test-ArrayContentsEqual -TestParams $testParams -DesiredArrayContents $testParams.AutoDiscoverSiteScope -GetResultParameterName "AutoDiscoverSiteScope" -ContextLabel "Verify AutoDiscoverSiteScope" -ItLabel "AutoDiscoverSiteScope should be empty"
+
+
+        #create ASA credentials
+        if ($null -eq $Global:ASACredentials)
+        {
+            $UserASA = "Fabrikam\ASA"
+            $Global:ASACredentials = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $UserASA, $PWordASA
+        }
+
+        #Now set ASA account
+        $testParams.Remove('AutoDiscoverSiteScope')
+        $testParams.Remove('AutoDiscoverServiceInternalUri')
+        $testParams.Add('AlternateServiceAccountCredential',$Global:ASACredentials)
+        $expectedGetResults.Add('AlternateServiceAccountCredential','UserName:Fabrikam\ASA Password:Pa$$w0rd!')
+        
+        Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Set AlternateServiceAccountCredential" -ExpectedGetResults $expectedGetResults
+
+        
+        #Now clear ASA account credentials
+        $testParams.Remove('AlternateServiceAccountCredential')
+        $testParams.RemoveAlternateServiceAccountCredentials = $true
+        $expectedGetResults.Remove('AlternateServiceAccountCredential')
+
+        Test-TargetResourceFunctionality -Params $testParams -ContextLabel "Clear AlternateServiceAccountCredential" -ExpectedGetResults $expectedGetResults
     }
 }
 else


### PR DESCRIPTION
The parameter IsOutOfService was not added due to the fact that it's deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/192)
<!-- Reviewable:end -->
