### PR TITLE
xExchAutoMountPoint and xExchJestressCleanup: Remove globals from disk part functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   after mount points have been successfully configured.
 - Fixed issue in xExchAutoMountPoint where Set-TargetResource fails
   if EnsureExchangeVolumeMountPointIsLast parameter is specified.
+- Updated xExchAutoMountPoint, xExchJetstressCleanup, and related DiskPart
+  functions to not use global variables.
 
 ## 1.21.0.0
 

--- a/DSCResources/MSFT_xExchJetstressCleanup/MSFT_xExchJetstressCleanup.psm1
+++ b/DSCResources/MSFT_xExchJetstressCleanup/MSFT_xExchJetstressCleanup.psm1
@@ -127,13 +127,13 @@ function Set-TargetResource
     #Delete associated mount points if requested
     if ($DeleteAssociatedMountPoints -eq $true -and $ParentFoldersToRemove.Count -gt 0)
     {
-        GetDiskInfo
+        $diskInfo = GetDiskInfo
 
         foreach ($parent in $ParentFoldersToRemove.Keys)
         {
             if ($null -eq (Get-ChildItem -LiteralPath "$($parent)" -ErrorAction SilentlyContinue))
             {
-                $volNum = MountPointExists -Path "$($parent)"
+                $volNum = MountPointExists -Path "$($parent)" -DiskInfo $diskInfo
 
                 if ($volNum -ge 0)
                 {
@@ -261,7 +261,7 @@ function Test-TargetResource
         }
 
         #First make sure DB and log folders were cleaned up
-        GetDiskInfo
+        $diskInfo = GetDiskInfo
 
         foreach ($folder in $FoldersToRemove)
         {
@@ -270,7 +270,7 @@ function Test-TargetResource
             {
                 $parent = GetParentFolderFromString -Folder "$($folder)"
 
-                if ((MountPointExists -Path "$($parent)") -ge 0)
+                if ((MountPointExists -Path "$($parent)" -DiskInfo $diskInfo) -ge 0)
                 {
                     Write-Verbose -Message "Folder '$($parent)' still has a mount point associated with it."
                     return $false


### PR DESCRIPTION
#### Pull Request (PR) description
Removes the use of DiskPart related Global variables in xExchAutoMountPoint and xExchJestressCleanup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/248)
<!-- Reviewable:end -->
