### PR TITLE
xExchWaitForDAG: Add WaitForComputerObject parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add WaitForComputerObject parameter to xExchWaitForDAG
+
 ## 1.24.0.0
 
 - xExchangeHelper.psm1: Renamed common functions to use proper Verb-Noun

--- a/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.psm1
+++ b/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.psm1
@@ -1,3 +1,29 @@
+<#
+    .SYNOPSIS
+        Retrieves the current DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Get-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -19,6 +45,10 @@ function Get-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -29,22 +59,47 @@ function Get-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+    $dagComp = Get-DAGComputerObject @PSBoundParameters
 
-    if ($null -ne $dag)
-    {
-        $returnValue = @{
-            Identity = [System.String] $Identity
-        }
-
+    $returnValue = @{
+        Identity          = [System.String] $Identity
+        DAGExists         = [System.Boolean] ($null -ne $dag)
+        DAGComputerExists = [System.Boolean] ($null -ne $dagComp)
     }
 
     $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Set-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -65,6 +120,10 @@ function Set-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -75,32 +134,44 @@ function Set-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $foundDAG = Wait-ForDatabaseAvailabilityGroup @PSBoundParameters
 
-    for ($i = 0; $i -lt $RetryCount; $i++)
+    if (!$foundDAG)
     {
-        if ($null -eq $dag)
-        {
-            Write-Warning "DAG '$($Identity)' does not yet exist. Sleeping for $($RetryIntervalSec) seconds."
-            Start-Sleep -Seconds $RetryIntervalSec
-
-            $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
-        }
-        else
-        {
-            break
-        }
-    }
-
-    if ($null -eq $dag)
-    {
-        throw "DAG '$($Identity)' does not yet exist. This will prevent resources that are dependant on this resource from executing. If you are running the DSC configuration in push mode, you will need to re-run the configuration once the database has been created."
+        throw 'Database Availability Group does not exist after waiting the specified amount of time.'
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests whether the desired configuration for this resource has been
+        applied.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Test-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -122,6 +193,10 @@ function Test-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -132,25 +207,53 @@ function Test-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+    $dagComp = Get-DAGComputerObject @PSBoundParameters
 
     $testResults = $true
 
-    if ($null -eq $dag)
+    if ($null -eq $dag -or ($WaitForComputerObject -and $null -eq $dagComp))
     {
-        Write-Verbose -Message "Database Availability Group does not yet exist"
+        Write-Warning -Message 'Database Availability Group does not yet exist'
         $testResults = $false
     }
 
     return $testResults
 }
 
-function GetDatabaseAvailabilityGroup
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Get-DatabaseAvailabilityGroupInternal
 {
     [CmdletBinding()]
+    [OutputType([System.Object])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -164,12 +267,192 @@ function GetDatabaseAvailabilityGroup
 
         [Parameter()]
         [System.String]
-        $DomainController
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
     )
 
     Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToKeep 'Identity','DomainController'
 
     return (Get-DatabaseAvailabilityGroup @PSBoundParameters -ErrorAction SilentlyContinue)
+}
+
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Get-DAGComputerObject
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
+    )
+
+    $getParams = @{
+        Identity = $Identity
+    }
+
+    if (![String]::IsNullOrEmpty($DomainController))
+    {
+        $getParams.Add('Server', $DomainController)
+    }
+
+    # ErrorAction SilentlyContinue doesn't always work with Get-ADComputer. Doing in Try/Catch instead.
+    try
+    {
+        $adComputer = Get-ADComputer @getParams -ErrorAction SilentlyContinue
+    }
+    catch
+    {
+        if ($WaitForComputerObject)
+        {
+            Write-Warning "Failed to find computer with name '$Identity' using Get-ADComputer."
+        }
+    }
+
+    return $adComputer
+}
+
+<#
+    .SYNOPSIS
+        Waits a specified amount of time to detect that the Database
+        Availability Group exists. Returns the true if it is detected within
+        the time limit.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Wait-ForDatabaseAvailabilityGroup
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject = $false,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
+    )
+
+    $foundDAG = $false
+
+    for ($i = 0; $i -lt $RetryCount; $i++)
+    {
+        $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+        $dagComp = Get-DAGComputerObject @PSBoundParameters
+
+        if ($null -eq $dag -or ($WaitForComputerObject -and $null -eq $dagComp))
+        {
+            Write-Warning "DAG '$($Identity)' object, or associated computer object (if requested) does not yet exist. Sleeping for $($RetryIntervalSec) seconds."
+            Start-Sleep -Seconds $RetryIntervalSec
+
+            $dag = $null
+            $dagComp = $null
+        }
+        else
+        {
+            $foundDAG = $true
+            break
+        }
+    }
+
+    return $foundDAG
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.schema.mof
+++ b/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.schema.mof
@@ -2,11 +2,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchWaitForDAG")]
 class MSFT_xExchWaitForDAG : OMI_BaseResource
 {
-    [Key] String Identity; //The name of the DAG
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote Powershell session to Exchange
-    [Write] String DomainController; //Domain controller to talk to when running Get-DatabaseAvailabilityGroup
-    [Write] Uint32 RetryIntervalSec; //How many seconds to wait between retries when checking whether the DAG exists. Defaults to 60.
-    [Write] Uint32 RetryCount; //Mount many retry attempts should be made to find the DAG before an exception is thrown. Defaults to 5.
+    [Key, Description("The name of the DAG to wait for.")] String Identity;
+    [Required, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to establish a remote Powershell session to Exchange")] String Credential;
+    [Write, Description("Optional Domain controller to use when running Get-DatabaseAvailabilityGroup")] String DomainController;
+    [Write, Description("Whether DSC should also wait for the DAG Computer account object to be discovered. Defaults to False.")] Boolean WaitForComputerObject;
+    [Write, Description("How many seconds to wait between retries when checking whether the DAG exists. Defaults to 60.")] Uint32 RetryIntervalSec;
+    [Write, Description("How many retry attempts should be made to find the DAG before an exception is thrown. Defaults to 5.")] Uint32 RetryCount;
 };
 
 

--- a/README.md
+++ b/README.md
@@ -1354,15 +1354,17 @@ configuration. Intended to be used as a DependsOn property by
 does not exist after the specified retry count and interval. If this happens,
 DSC configurations run in push mode will need to be re-executed.
 
-* **Identity**: The name of the DAG.
-* **Credential**: Credentials used to establish a remote PowerShell session to Exchange.
-* **DomainController**: Domain controller to talk to when running Get-DatabaseAvailabilityGroup.
+* **Identity**: The name of the DAG to wait for.
+* **Credential**: Credentials used to establish a remote PowerShell session to
+  Exchange.
+* **DomainController**: Optional Domain controller to use when running
+  Get-DatabaseAvailabilityGroup.
+* **WaitForComputerObject**: Whether DSC should also wait for the DAG Computer
+  account object to be discovered. Defaults to False.
 * **RetryIntervalSec**: How many seconds to wait between retries when checking
-  whether the DAG exists.
-  Defaults to 60.
-* **RetryCount**: Mount many retry attempts should be made to find the DAG
-  before an exception is thrown.
-  Defaults to 5.
+  whether the DAG exists. Defaults to 60.
+* **RetryCount**: How many retry attempts should be made to find the DAG
+  before an exception is thrown. Defaults to 5.
 
 ### xExchWaitForMailboxDatabase
 

--- a/Tests/TestHelpers/xExchangeTestHelper.psm1
+++ b/Tests/TestHelpers/xExchangeTestHelper.psm1
@@ -1,7 +1,22 @@
 <#
-    Function to be used within pester for end to end testing of Get/Set/Test-TargetResource
-    Function first calls Set-TargetResource with provided parameters, then runs Get and Test-TargetResource,
-    and ensures they match $ExpectedGetResults and $ExpectedTestResult
+    .SYNOPSIS
+        Function to be used within pester for end to end testing of
+        Get/Set/Test-TargetResource. Function first calls Set-TargetResource
+        with provided parameters, then runs Get and Test-TargetResource, and
+        ensures they match $ExpectedGetResults and $ExpectedTestResult
+
+    .PARAMETER Params
+        The Parameters to pass when calling Get/Set/Test-TargetResource.
+
+    .PARAMETER ContextLabel
+        The label to use within the Context block of tests.
+
+    .PARAMETER ExpectedGetResults
+        A hashtable containing the expected return values from
+        Get-TargetResource.
+
+    .PARAMETER ExpectedTestResult
+        The expected return value from Test-TargetResource.
 #>
 function Test-TargetResourceFunctionality
 {
@@ -26,58 +41,38 @@ function Test-TargetResourceFunctionality
     )
 
     Context $ContextLabel {
-        [System.Boolean]$testResult = Test-TargetResource @Params -Verbose
+        if ($null -eq ($Params.Keys | Where-Object -FilterScript {$_ -like 'Verbose'}))
+        {
+            $Params.Add('Verbose', $true)
+        }
+
+        [System.Boolean] $testResult = Test-TargetResource @Params
 
         Write-Verbose -Message "Test-TargetResource results before running Set-TargetResource: $testResult"
 
-        Set-TargetResource @Params -Verbose
+        Set-TargetResource @Params
 
-        [System.Collections.Hashtable]$getResult = Get-TargetResource @Params -Verbose
-        [System.Boolean]$testResult = Test-TargetResource @Params -Verbose
+        [System.Collections.Hashtable] $getResult = Get-TargetResource @Params
+        [System.Boolean] $testResult = Test-TargetResource @Params
 
-        #The ExpectedGetResults are $null, so let's check that what we got back is $null
+        # The ExpectedGetResults are $null, so let's check that what we got back is $null
         if ($null -eq $ExpectedGetResults)
         {
             It 'Get-TargetResource: Should Be Null' {
-                $getResult | Should BeNullOrEmpty
+                $getResult | Should -BeNullOrEmpty
             }
         }
         else
         {
-            <#
-                Check the members of the Get-TargetResource results and make sure the result types
-                match those of the function parameters
-            #>
-            $getTargetResourceCommand = Get-Command Get-TargetResource
+            Test-CommonGetTargetResourceFunctionality -GetResult $getResult
 
-            It "Only 1 Get-TargetResource function is loaded" {
-                $getTargetResourceCommand.Count -eq 1 | Should Be $true
-            }
-
-            if ($getTargetResourceCommand.Count -eq 1)
-            {
-                foreach ($getTargetResourceParam in $getTargetResourceCommand.Parameters.Keys | Where-Object {$getResult.ContainsKey($_)})
-                {
-                    $getResultMemberType = '$null'
-
-                    if ($null -ne ($getResult[$getTargetResourceParam]))
-                    {
-                        $getResultMemberType = $getResult[$getTargetResourceParam].GetType().ToString()
-                    }
-
-                    It "Get-TargetResource: Parameter '$getTargetResourceParam' expects return type: '$($getTargetResourceCommand.Parameters[$getTargetResourceParam].ParameterType.ToString())'. Actual return type: '$getResultMemberType'" {
-                        ($getTargetResourceCommand.Parameters[$getTargetResourceParam].ParameterType.ToString()) -eq $getResultMemberType | Should Be $true
-                    }
-                }
-            }
-
-            #Test each individual key in $ExpectedGetResult to see if they exist, and if the expected value matches
+            # Test each individual key in $ExpectedGetResult to see if they exist, and if the expected value matches
             foreach ($key in $ExpectedGetResults.Keys)
             {
                 $getContainsKey = $getResult.ContainsKey($key)
 
                 It "Get-TargetResource: Contains Key: $($key)" {
-                    $getContainsKey | Should Be $true
+                    $getContainsKey | Should -Be $true
                 }
 
                 if ($getContainsKey)
@@ -106,15 +101,82 @@ function Test-TargetResourceFunctionality
                     }
 
                     It "Get-TargetResource: Value Matches for Key: $($key)" {
-                        $getValueMatchesForKey | Should Be $true
+                        $getValueMatchesForKey | Should -Be $true
                     }
                 }
             }
         }
 
-        #Test the Test-TargetResource results
+        # Test the Test-TargetResource results
         It 'Test-TargetResource' {
-            $testResult | Should Be $ExpectedTestResult
+            $testResult | Should -Be $ExpectedTestResult
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Runs Get-TargetTesource, or takes the results of a previous
+        Get-TargetResource execution, and performs common tests against the
+        results. The function must be provided either the results from a
+        previous Get-TargetResource execution, or the parameters to send to
+        Get-TargetResource, but not both. If neither parameter is specified,
+        or both parameters are specified, the function will throw an exception.
+
+    .PARAMETER GetResult
+        The results of a previous Get-TargetResource execution.
+
+    .PARAMETER GetTargetResourceParams
+        The parameters that should be passed to Get-TargetResource.
+#>
+function Test-CommonGetTargetResourceFunctionality
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $GetResult,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $GetTargetResourceParams
+    )
+
+    if (($GetResult.Count -eq 0 -and $GetTargetResourceParams.Count -eq 0) -or ($GetResult.Count -gt 0 -and $GetTargetResourceParams.Count -gt 0))
+    {
+        throw 'Either the GetResult or GetTargetResourceParams parameters must be specified with non-empty hashtables, but not both.'
+    }
+
+    if ($GetResult.Count -eq 0)
+    {
+        $GetResult = Get-TargetResource @GetTargetResourceParams
+    }
+
+    It 'Should return a hashtable of properties' {
+        $GetResult | Should -Be -Not $null
+    }
+
+    $getTargetResourceCommand = Get-Command Get-TargetResource
+
+    It 'Only 1 Get-TargetResource function should be loaded' {
+        $getTargetResourceCommand.Count -eq 1 | Should -Be $true
+    }
+
+    if ($getTargetResourceCommand.Count -eq 1)
+    {
+        foreach ($getTargetResourceParam in $getTargetResourceCommand.Parameters.Keys | Where-Object -FilterScript {$GetResult.ContainsKey($_)})
+        {
+            $getResultMemberType = '$null'
+
+            if ($null -ne ($GetResult[$getTargetResourceParam]))
+            {
+                $getResultMemberType = $GetResult[$getTargetResourceParam].GetType().ToString()
+            }
+
+            It "Should return a value of type '$($getTargetResourceCommand.Parameters[$getTargetResourceParam].ParameterType.ToString())' for hashtable member '$getTargetResourceParam'. Actual return type: '$getResultMemberType'" {
+                ($getTargetResourceCommand.Parameters[$getTargetResourceParam].ParameterType.ToString()) -eq $getResultMemberType | Should -Be $true
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Adds a WaitForComputerObject parameter to xExchWaitForDAG. When set to true, this specifies that the resource should not just wait to detect the Exchange DAG object via the Exchange cmdlets, but that it should also detect the AD Computer object using Get-ADComputer.

Also adds Unit tests to get to 100% code coverage for xExchWaitForDAG.

Note that the xExchangeTestHelper.psm1 changes included in this request overlap with https://github.com/PowerShell/xExchange/pull/326.

#### This Pull Request (PR) fixes the following issues
Fixes #208 
Fixes #308 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).