### PR TITLE
xExchWaitForDAG: Add WaitForComputerObject parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add spaces between array members.
 - Add initial set of Unit Tests (mostly Get-TargetResource tests) for all
   remaining resource files.
+- Add WaitForComputerObject parameter to xExchWaitForDAG
 
 ## 1.24.0.0
 

--- a/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.psm1
+++ b/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.psm1
@@ -1,3 +1,29 @@
+<#
+    .SYNOPSIS
+        Retrieves the current DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Get-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -19,6 +45,10 @@ function Get-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -29,22 +59,47 @@ function Get-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+    $dagComp = Get-DAGComputerObject @PSBoundParameters
 
-    if ($null -ne $dag)
-    {
-        $returnValue = @{
-            Identity = [System.String] $Identity
-        }
-
+    $returnValue = @{
+        Identity          = [System.String] $Identity
+        DAGExists         = [System.Boolean] ($null -ne $dag)
+        DAGComputerExists = [System.Boolean] ($null -ne $dagComp)
     }
 
     $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Set-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -65,6 +120,10 @@ function Set-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -75,32 +134,44 @@ function Set-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $foundDAG = Wait-ForDatabaseAvailabilityGroup @PSBoundParameters
 
-    for ($i = 0; $i -lt $RetryCount; $i++)
+    if (!$foundDAG)
     {
-        if ($null -eq $dag)
-        {
-            Write-Warning "DAG '$($Identity)' does not yet exist. Sleeping for $($RetryIntervalSec) seconds."
-            Start-Sleep -Seconds $RetryIntervalSec
-
-            $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
-        }
-        else
-        {
-            break
-        }
-    }
-
-    if ($null -eq $dag)
-    {
-        throw "DAG '$($Identity)' does not yet exist. This will prevent resources that are dependant on this resource from executing. If you are running the DSC configuration in push mode, you will need to re-run the configuration once the database has been created."
+        throw 'Database Availability Group does not exist after waiting the specified amount of time.'
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests whether the desired configuration for this resource has been
+        applied.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
 function Test-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -122,6 +193,10 @@ function Test-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
         [System.UInt32]
         $RetryIntervalSec = 60,
 
@@ -132,25 +207,53 @@ function Test-TargetResource
 
     Write-FunctionEntry -Parameters @{'Identity' = $Identity} -Verbose:$VerbosePreference
 
-    #Establish remote Powershell session
+    # Establish remote Powershell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
 
-    $dag = GetDatabaseAvailabilityGroup @PSBoundParameters
+    $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+    $dagComp = Get-DAGComputerObject @PSBoundParameters
 
     $testResults = $true
 
-    if ($null -eq $dag)
+    if ($null -eq $dag -or ($WaitForComputerObject -and $null -eq $dagComp))
     {
-        Write-Verbose -Message "Database Availability Group does not yet exist"
+        Write-Warning -Message 'Database Availability Group does not yet exist'
         $testResults = $false
     }
 
     return $testResults
 }
 
-function GetDatabaseAvailabilityGroup
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Get-DatabaseAvailabilityGroupInternal
 {
     [CmdletBinding()]
+    [OutputType([System.Object])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -164,12 +267,189 @@ function GetDatabaseAvailabilityGroup
 
         [Parameter()]
         [System.String]
-        $DomainController
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
     )
 
     Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToKeep 'Identity', 'DomainController'
 
     return (Get-DatabaseAvailabilityGroup @PSBoundParameters -ErrorAction SilentlyContinue)
+}
+
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Get-DAGComputerObject
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
+    )
+
+    $getParams = @{
+        Identity = $Identity
+    }
+
+    if (![String]::IsNullOrEmpty($DomainController))
+    {
+        $getParams.Add('Server', $DomainController)
+    }
+
+    # ErrorAction SilentlyContinue doesn't always work with Get-ADComputer. Doing in Try/Catch instead.
+    try
+    {
+        $adComputer = Get-ADComputer @getParams -ErrorAction SilentlyContinue
+    }
+    catch
+    {
+        if ($WaitForComputerObject)
+        {
+            Write-Warning "Failed to find computer with name '$Identity' using Get-ADComputer."
+        }
+    }
+
+    return $adComputer
+}
+
+<#
+    .SYNOPSIS
+        Waits a specified amount of time to detect that the Database
+        Availability Group exists. Returns the true if it is detected within
+        the time limit.
+
+    .PARAMETER Identity
+        The name of the DAG to wait for.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote Powershell session to Exchange.
+
+    .PARAMETER DomainController
+        Optional Domain controller to use when running
+        Get-DatabaseAvailabilityGroup.
+
+    .PARAMETER WaitForComputerObject
+        Whether DSC should also wait for the DAG Computer account object to
+        be discovered. Defaults to False.
+
+    .PARAMETER RetryIntervalSec
+        How many seconds to wait between retries when checking whether the DAG
+        exists. Defaults to 60.
+
+    .PARAMETER RetryCount
+        How many retry attempts should be made to find the DAG before an
+        exception is thrown. Defaults to 5.
+#>
+function Wait-ForDatabaseAvailabilityGroup
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Identity,
+
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $DomainController,
+
+        [Parameter()]
+        [System.Boolean]
+        $WaitForComputerObject,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryIntervalSec = 60,
+
+        [Parameter()]
+        [System.UInt32]
+        $RetryCount = 5
+    )
+
+    $foundDAG = $false
+
+    for ($i = 0; $i -lt $RetryCount; $i++)
+    {
+        $dag = Get-DatabaseAvailabilityGroupInternal @PSBoundParameters
+        $dagComp = Get-DAGComputerObject @PSBoundParameters
+
+        if ($null -eq $dag -or ($WaitForComputerObject -and $null -eq $dagComp))
+        {
+            Write-Warning "DAG '$($Identity)' object, or associated computer object (if requested) does not yet exist. Sleeping for $($RetryIntervalSec) seconds."
+            Start-Sleep -Seconds $RetryIntervalSec
+        }
+        else
+        {
+            $foundDAG = $true
+            break
+        }
+    }
+
+    return $foundDAG
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.schema.mof
+++ b/DSCResources/MSFT_xExchWaitForDAG/MSFT_xExchWaitForDAG.schema.mof
@@ -2,11 +2,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchWaitForDAG")]
 class MSFT_xExchWaitForDAG : OMI_BaseResource
 {
-    [Key] String Identity; //The name of the DAG
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote Powershell session to Exchange
-    [Write] String DomainController; //Domain controller to talk to when running Get-DatabaseAvailabilityGroup
-    [Write] Uint32 RetryIntervalSec; //How many seconds to wait between retries when checking whether the DAG exists. Defaults to 60.
-    [Write] Uint32 RetryCount; //Mount many retry attempts should be made to find the DAG before an exception is thrown. Defaults to 5.
+    [Key, Description("The name of the DAG to wait for.")] String Identity;
+    [Required, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to establish a remote Powershell session to Exchange")] String Credential;
+    [Write, Description("Optional Domain controller to use when running Get-DatabaseAvailabilityGroup")] String DomainController;
+    [Write, Description("Whether DSC should also wait for the DAG Computer account object to be discovered. Defaults to False.")] Boolean WaitForComputerObject;
+    [Write, Description("How many seconds to wait between retries when checking whether the DAG exists. Defaults to 60.")] Uint32 RetryIntervalSec;
+    [Write, Description("How many retry attempts should be made to find the DAG before an exception is thrown. Defaults to 5.")] Uint32 RetryCount;
 };
 
 

--- a/README.md
+++ b/README.md
@@ -1354,15 +1354,17 @@ configuration. Intended to be used as a DependsOn property by
 does not exist after the specified retry count and interval. If this happens,
 DSC configurations run in push mode will need to be re-executed.
 
-* **Identity**: The name of the DAG.
-* **Credential**: Credentials used to establish a remote PowerShell session to Exchange.
-* **DomainController**: Domain controller to talk to when running Get-DatabaseAvailabilityGroup.
+* **Identity**: The name of the DAG to wait for.
+* **Credential**: Credentials used to establish a remote PowerShell session to
+  Exchange.
+* **DomainController**: Optional Domain controller to use when running
+  Get-DatabaseAvailabilityGroup.
+* **WaitForComputerObject**: Whether DSC should also wait for the DAG Computer
+  account object to be discovered. Defaults to False.
 * **RetryIntervalSec**: How many seconds to wait between retries when checking
-  whether the DAG exists.
-  Defaults to 60.
-* **RetryCount**: Mount many retry attempts should be made to find the DAG
-  before an exception is thrown.
-  Defaults to 5.
+  whether the DAG exists. Defaults to 60.
+* **RetryCount**: How many retry attempts should be made to find the DAG
+  before an exception is thrown. Defaults to 5.
 
 ### xExchWaitForMailboxDatabase
 

--- a/Tests/Unit/MSFT_xExchWaitForDAG.tests.ps1
+++ b/Tests/Unit/MSFT_xExchWaitForDAG.tests.ps1
@@ -65,7 +65,7 @@ try
             Mock -CommandName Write-FunctionEntry -Verifiable
             Mock -CommandName Get-RemoteExchangeSession -Verifiable
 
-            Context 'When Set-TargetResource is called and the wait for the DAG is successful' {
+            Context 'When the wait for the DAG is successful' {
                 It 'Should return without throwing an exception' {
                     Mock -CommandName Wait-ForDatabaseAvailabilityGroup -Verifiable -MockWith { return 'DAG' }
 
@@ -73,7 +73,7 @@ try
                 }
             }
 
-            Context 'When Set-TargetResource is called and the wait for the DAG is not successful' {
+            Context 'When the wait for the DAG is not successful' {
                 It 'Should throw an exception' {
                     Mock -CommandName Wait-ForDatabaseAvailabilityGroup -Verifiable
 
@@ -90,7 +90,7 @@ try
             Mock -CommandName Write-FunctionEntry -Verifiable
             Mock -CommandName Get-RemoteExchangeSession -Verifiable
 
-            Context 'When Test-TargetResource is called and the DAG does not exist' {
+            Context 'When the DAG does not exist' {
                 It 'Should return false' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -100,7 +100,7 @@ try
                 }
             }
 
-            Context 'When Test-TargetResource is called, the DAG exists, the computer does not exist, but WaitForComputerObject is not specified' {
+            Context 'When the DAG exists, the computer does not exist, and WaitForComputerObject is not specified' {
                 It 'Should return true' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -109,7 +109,7 @@ try
                 }
             }
 
-            Context 'When Test-TargetResource is called, the DAG exists, the computer does not exist, and WaitForComputerObject is specified' {
+            Context 'When the DAG exists, the computer does not, and WaitForComputerObject is specified' {
                 It 'Should return false' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -123,7 +123,7 @@ try
                 }
             }
 
-            Context 'When Test-TargetResource is called, the DAG exists, the computer exists, and WaitForComputerObject is specified' {
+            Context 'When the DAG exists, the computer exists, and WaitForComputerObject is specified' {
                 It 'Should return true' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable -MockWith { return 'Computer' }
@@ -175,7 +175,7 @@ try
                 }
             }
 
-            Context 'When Get-DAGComputerObject is called, Get-ADComputer throws an exception, and WaitForComputerObject is specified' {
+            Context 'When Get-ADComputer throws an exception, and WaitForComputerObject is specified' {
                 It 'Should write a warning' {
                     Mock -CommandName Get-ADComputer -Verifiable -MockWith { throw 'Exception' }
                     Mock -CommandName Write-Warning -Verifiable
@@ -197,7 +197,7 @@ try
             $basicTargetResourceParams.Add('RetryIntervalSec', 1)
             $basicTargetResourceParams.Add('RetryCount', 1)
 
-            Context 'When Wait-ForDatabaseAvailabilityGroup is called and the DAG does not exist' {
+            Context 'When the DAG does not exist' {
                 It 'Should return false' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -208,7 +208,7 @@ try
                 }
             }
 
-            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer does not exist, but WaitForComputerObject is not specified' {
+            Context 'When the DAG exists, the computer does not, and WaitForComputerObject is not specified' {
                 It 'Should return true' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -217,7 +217,7 @@ try
                 }
             }
 
-            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer does not exist, and WaitForComputerObject is specified' {
+            Context 'When the DAG exists, the computer does not, and WaitForComputerObject is specified' {
                 It 'Should return false' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable
@@ -232,7 +232,7 @@ try
                 }
             }
 
-            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer exists, and WaitForComputerObject is specified' {
+            Context 'When the DAG exists, the computer exists, and WaitForComputerObject is specified' {
                 It 'Should return true' {
                     Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
                     Mock -CommandName Get-DAGComputerObject -Verifiable -MockWith { return 'Computer' }

--- a/Tests/Unit/MSFT_xExchWaitForDAG.tests.ps1
+++ b/Tests/Unit/MSFT_xExchWaitForDAG.tests.ps1
@@ -37,23 +37,216 @@ try
     Invoke-TestSetup
 
     InModuleScope $script:DSCResourceName {
+        $basicTargetResourceParams = @{
+            Identity   = 'DAGName'
+            Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'fakeuser', (New-Object -TypeName System.Security.SecureString)
+        }
+
         Describe 'MSFT_xExchWaitForDAG\Get-TargetResource' -Tag 'Get' {
             AfterEach {
                 Assert-VerifiableMock
             }
 
-            $getTargetResourceParams = @{
-                Identity   = 'DAGName'
-                Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'fakeuser', (New-Object -TypeName System.Security.SecureString)
-            }
-
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
                 Mock -CommandName Get-RemoteExchangeSession -Verifiable
-                Mock -CommandName GetDatabaseAvailabilityGroup -Verifiable -MockWith { return 'DAG' }
+                Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                Mock -CommandName Get-DAGComputerObject -Verifiable -MockWith { return 'Computer' }
 
-                Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
+                Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $basicTargetResourceParams
             }
+        }
+
+        Describe 'MSFT_xExchWaitForDAG\Set-TargetResource' -Tag 'Set' {
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            Mock -CommandName Write-FunctionEntry -Verifiable
+            Mock -CommandName Get-RemoteExchangeSession -Verifiable
+
+            Context 'When Set-TargetResource is called and the wait for the DAG is successful' {
+                It 'Should return without throwing an exception' {
+                    Mock -CommandName Wait-ForDatabaseAvailabilityGroup -Verifiable -MockWith { return 'DAG' }
+
+                    { Set-TargetResource @basicTargetResourceParams } | Should -Not -Throw
+                }
+            }
+
+            Context 'When Set-TargetResource is called and the wait for the DAG is not successful' {
+                It 'Should throw an exception' {
+                    Mock -CommandName Wait-ForDatabaseAvailabilityGroup -Verifiable
+
+                    { Set-TargetResource @basicTargetResourceParams } | Should -Throw -ExpectedMessage 'Database Availability Group does not exist after waiting the specified amount of time.'
+                }
+            }
+        }
+
+        Describe 'MSFT_xExchWaitForDAG\Test-TargetResource' -Tag 'Test' {
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            Mock -CommandName Write-FunctionEntry -Verifiable
+            Mock -CommandName Get-RemoteExchangeSession -Verifiable
+
+            Context 'When Test-TargetResource is called and the DAG does not exist' {
+                It 'Should return false' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+                    Mock -CommandName Write-Warning -Verifiable
+
+                    Test-TargetResource @basicTargetResourceParams | Should -Be $false
+                }
+            }
+
+            Context 'When Test-TargetResource is called, the DAG exists, the computer does not exist, but WaitForComputerObject is not specified' {
+                It 'Should return true' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+
+                    Test-TargetResource @basicTargetResourceParams | Should -Be $true
+                }
+            }
+
+            Context 'When Test-TargetResource is called, the DAG exists, the computer does not exist, and WaitForComputerObject is specified' {
+                It 'Should return false' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+                    Mock -CommandName Write-Warning -Verifiable
+
+                    $basicTargetResourceParams.Add('WaitForComputerObject', $true)
+
+                    Test-TargetResource @basicTargetResourceParams | Should -Be $false
+
+                    $basicTargetResourceParams.Remove('WaitForComputerObject')
+                }
+            }
+
+            Context 'When Test-TargetResource is called, the DAG exists, the computer exists, and WaitForComputerObject is specified' {
+                It 'Should return true' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable -MockWith { return 'Computer' }
+
+                    $basicTargetResourceParams.Add('WaitForComputerObject', $true)
+
+                    Test-TargetResource @basicTargetResourceParams | Should -Be $true
+
+                    $basicTargetResourceParams.Remove('WaitForComputerObject')
+                }
+            }
+        }
+
+        Describe 'MSFT_xExchWaitForDAG\Get-DatabaseAvailabilityGroupInternal' -Tag 'Helper' {
+            # Override Exchange cmdlets
+            function Get-DatabaseAvailabilityGroup {}
+
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            Context 'When Get-DatabaseAvailabilityGroupInternal is called' {
+                It 'Should call expected functions' {
+                    Mock -CommandName Remove-FromPSBoundParametersUsingHashtable -Verifiable
+                    Mock -CommandName Get-DatabaseAvailabilityGroup -Verifiable
+
+                    Get-DatabaseAvailabilityGroupInternal @basicTargetResourceParams
+                }
+            }
+        }
+
+        Describe 'MSFT_xExchWaitForDAG\Get-DAGComputerObject' -Tag 'Helper' {
+            # Override Active Directory cmdlets
+            function Get-ADComputer {}
+
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            Context 'When Get-DAGComputerObject is called' {
+                It 'Should call expected functions' {
+                    Mock -CommandName Get-ADComputer -Verifiable
+
+                    $basicTargetResourceParams.Add('DomainController', 'DC')
+
+                    Get-DAGComputerObject @basicTargetResourceParams
+
+                    $basicTargetResourceParams.Remove('DomainController')
+                }
+            }
+
+            Context 'When Get-DAGComputerObject is called, Get-ADComputer throws an exception, and WaitForComputerObject is specified' {
+                It 'Should write a warning' {
+                    Mock -CommandName Get-ADComputer -Verifiable -MockWith { throw 'Exception' }
+                    Mock -CommandName Write-Warning -Verifiable
+
+                    $basicTargetResourceParams.Add('WaitForComputerObject', $true)
+
+                    Get-DAGComputerObject @basicTargetResourceParams
+
+                    $basicTargetResourceParams.Remove('WaitForComputerObject')
+                }
+            }
+        }
+
+        Describe 'MSFT_xExchWaitForDAG\Wait-ForDatabaseAvailabilityGroup' -Tag 'Helper' {
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            $basicTargetResourceParams.Add('RetryIntervalSec', 1)
+            $basicTargetResourceParams.Add('RetryCount', 1)
+
+            Context 'When Wait-ForDatabaseAvailabilityGroup is called and the DAG does not exist' {
+                It 'Should return false' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+                    Mock -CommandName Write-Warning -Verifiable
+                    Mock -CommandName Start-Sleep -Verifiable
+
+                    Wait-ForDatabaseAvailabilityGroup @basicTargetResourceParams | Should -Be $false
+                }
+            }
+
+            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer does not exist, but WaitForComputerObject is not specified' {
+                It 'Should return true' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+
+                    Wait-ForDatabaseAvailabilityGroup @basicTargetResourceParams | Should -Be $true
+                }
+            }
+
+            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer does not exist, and WaitForComputerObject is specified' {
+                It 'Should return false' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable
+                    Mock -CommandName Write-Warning -Verifiable
+                    Mock -CommandName Start-Sleep -Verifiable
+
+                    $basicTargetResourceParams.Add('WaitForComputerObject', $true)
+
+                    Wait-ForDatabaseAvailabilityGroup @basicTargetResourceParams | Should -Be $false
+
+                    $basicTargetResourceParams.Remove('WaitForComputerObject')
+                }
+            }
+
+            Context 'When Wait-ForDatabaseAvailabilityGroup is called, the DAG exists, the computer exists, and WaitForComputerObject is specified' {
+                It 'Should return true' {
+                    Mock -CommandName Get-DatabaseAvailabilityGroupInternal -Verifiable -MockWith { return 'DAG' }
+                    Mock -CommandName Get-DAGComputerObject -Verifiable -MockWith { return 'Computer' }
+
+                    $basicTargetResourceParams.Add('WaitForComputerObject', $true)
+
+                    Wait-ForDatabaseAvailabilityGroup @basicTargetResourceParams | Should -Be $true
+
+                    $basicTargetResourceParams.Remove('WaitForComputerObject')
+                }
+            }
+
+            $basicTargetResourceParams.Remove('RetryIntervalSec')
+            $basicTargetResourceParams.Remove('RetryCount')
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Adds a WaitForComputerObject parameter to xExchWaitForDAG. When set to true, this specifies that the resource should not just wait to detect the Exchange DAG object via the Exchange cmdlets, but that it should also detect the AD Computer object using Get-ADComputer.

Also adds Unit tests to get to 100% code coverage for xExchWaitForDAG.

Note that the xExchangeTestHelper.psm1 changes included in this request overlap with https://github.com/PowerShell/xExchange/pull/326.

#### This Pull Request (PR) fixes the following issues
Fixes #208 
Fixes #308 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/330)
<!-- Reviewable:end -->
