### PR TITLE
Fixes for #335 and #336

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Add WaitForComputerObject parameter to xExchWaitForDAG
 - Add spaces between comment hashtags and comments.
 - Add space between variable types and variables.
+- Fixes issue where xExchMailboxDatabase fails to test for a Journal Recipient
+  because the module did not load the Get-Recipient cmdlet (#335).
+- Fixes broken Integration tests in
+  MSFT_xExchMaintenanceMode.Integration.Tests.ps1 (#336).
 
 ## 1.24.0.0
 

--- a/DSCResources/MSFT_xExchMailboxDatabase/MSFT_xExchMailboxDatabase.psm1
+++ b/DSCResources/MSFT_xExchMailboxDatabase/MSFT_xExchMailboxDatabase.psm1
@@ -558,7 +558,7 @@ function Test-TargetResource
 
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential `
-                             -CommandsToLoad 'Get-MailboxDatabase', 'Get-Mailbox', 'Set-AdServerSettings'`
+                             -CommandsToLoad 'Get-MailboxDatabase', 'Get-Recipient', 'Set-AdServerSettings'`
                              -Verbose:$VerbosePreference
 
     # Check for non-existent parameters in Exchange 2013

--- a/Tests/Integration/MSFT_xExchExchangeServer.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchExchangeServer.Integration.Tests.ps1
@@ -91,6 +91,9 @@ if ($null -ne $adModule)
             {
                 throw 'Failed to determine distinguishedName of Exchange Server object'
             }
+
+            # Remove our remote Exchange session so as not to interfere with actual Integration testing
+            Remove-RemoteExchangeSession
         }
 
         # Get the product key to use for testing

--- a/Tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
@@ -72,6 +72,9 @@ if ($exchangeInstalled)
     $testMailboxADObjectIDString = ([Microsoft.Exchange.Data.Directory.ADObjectId]::ParseDnOrGuid($testMailbox.DistinguishedName)).ToString()
     $testMailboxSecondaryAddress = ($testMailbox.EmailAddresses | Where-Object {$_.IsPrimaryAddress -eq $false -and $_.Prefix -like 'SMTP'} | Select-Object -First 1).AddressString
 
+    # Remove our remote Exchange session so as not to interfere with actual Integration testing
+    Remove-RemoteExchangeSession
+
     Describe 'Test Creating a DB and Setting Properties with xExchMailboxDatabase' {
         # First create and set properties on a test database
         $testParams = @{

--- a/Tests/Integration/MSFT_xExchMaintenanceMode.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchMaintenanceMode.Integration.Tests.ps1
@@ -23,14 +23,22 @@ Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -P
 <#
     .SYNOPSIS
         Runs tests to ensure that the server is fully out of maintenance mode
+
+    .PARAMETER GetTargetResourceParameters
+        The paramaters to pass to Get-TargetResource.
 #>
 function Test-ServerIsOutOfMaintenanceMode
 {
     [CmdletBinding()]
-    param()
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $GetTargetResourceParameters
+    )
 
     Context 'Do additional Get-TargetResource verification after taking server out of maintenance mode' {
-        [System.Collections.Hashtable] $getResult = Get-TargetResource @testParams -Verbose
+        [System.Collections.Hashtable] $getResult = Get-TargetResource @GetTargetResourceParameters -Verbose
 
         It 'ActiveComponentCount is greater than 0' {
             $getResult.ActiveComponentCount -gt 0 | Should Be $true
@@ -409,7 +417,7 @@ if ($exchangeInstalled)
         Test-TargetResourceFunctionality -Params $testParams `
                                          -ContextLabel 'Take server out of maintenance mode' `
                                          -ExpectedGetResults $expectedGetResults
-        Test-ServerIsOutOfMaintenanceMode
+        Test-ServerIsOutOfMaintenanceMode -GetTargetResourceParameters $testParams
         Wait-Verbose -Verbose
 
         # Test passing in UpgradedServerVersion that is lower than the current server version
@@ -471,7 +479,7 @@ if ($exchangeInstalled)
         Test-TargetResourceFunctionality -Params $testParams `
                                          -ContextLabel 'Take server out of maintenance mode using Domain Controller switch' `
                                          -ExpectedGetResults $expectedGetResults
-        Test-ServerIsOutOfMaintenanceMode
+        Test-ServerIsOutOfMaintenanceMode -GetTargetResourceParameters $testParams
         Wait-Verbose -Verbose
 
         # Test SetInactiveComponentsFromAnyRequesterToActive Parameter

--- a/Tests/Integration/MSFT_xExchOwaVirtualDirectory.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchOwaVirtualDirectory.Integration.Tests.ps1
@@ -46,6 +46,9 @@ if ($exchangeInstalled)
         return
     }
 
+    # Remove our remote Exchange session so as not to interfere with actual Integration testing
+    Remove-RemoteExchangeSession
+
     Describe 'Test Setting Properties with xExchOwaVirtualDirectory' {
         $testParams = @{
             Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"

--- a/Tests/Integration/MSFT_xExchUMService.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchUMService.Integration.Tests.ps1
@@ -46,6 +46,9 @@ if ($exchangeInstalled)
             }
         }
 
+        # Remove our remote Exchange session so as not to interfere with actual Integration testing
+        Remove-RemoteExchangeSession
+
         Describe 'Test Setting Properties with xExchUMService' {
             $testParams = @{
                 Identity =  $env:COMPUTERNAME

--- a/Tests/TestHelpers/xExchangeTestHelper.psm1
+++ b/Tests/TestHelpers/xExchangeTestHelper.psm1
@@ -41,9 +41,12 @@ function Test-TargetResourceFunctionality
     )
 
     Context $ContextLabel {
+        $addedVerbose = $false
+
         if ($null -eq ($Params.Keys | Where-Object -FilterScript {$_ -like 'Verbose'}))
         {
             $Params.Add('Verbose', $true)
+            $addedVerbose = $true
         }
 
         [System.Boolean] $testResult = Test-TargetResource @Params
@@ -110,6 +113,11 @@ function Test-TargetResourceFunctionality
         # Test the Test-TargetResource results
         It 'Test-TargetResource' {
             $testResult | Should -Be $ExpectedTestResult
+        }
+
+        if ($addedVerbose)
+        {
+            $Params.Remove('Verbose')
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- Fixes issue where xExchMailboxDatabase fails to test for a Journal Recipient because the module did not load the Get-Recipient cmdlet.
- Fixes broken Integration tests in MSFT_xExchMaintenanceMode.Integration.Tests.ps1.

#### This Pull Request (PR) fixes the following issues
- Fixes #335 
- Fixes #336

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/337)
<!-- Reviewable:end -->
