### PR TITLE
Rename poorly named functions in xExchangeDiskPart.psm1 and MSFT_xExchAutoMountPoint.psm1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   MSFT_xExchMaintenanceMode.Integration.Tests.ps1 (#336).
 - Fix issue where Get-ReceiveConnector against an Absent connector causes an
   error to be logged in the MSExchange Management log.
+- Rename poorly named functions in xExchangeDiskPart.psm1 and
+  MSFT_xExchAutoMountPoint.psm1, and add comment based help.
 
 ## 1.24.0.0
 

--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.schema.mof
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.schema.mof
@@ -8,12 +8,12 @@ class MSFT_xExchAutoMountPoint : OMI_BaseResource
     [Required, Description("An array of strings containing the databases for each disk. Databases on the same disk should be in the same string, and comma separated. Example: 'DB1,DB2','DB3,DB4'. This puts DB1 and DB2 on one disk, and DB3 and DB4 on another.")] String DiskToDBMap[];
     [Required, Description("How many spare volumes will be available.")] Uint32 SpareVolumeCount;
     [Write, Description("Whether the EXVOL mount point should be moved to be the last mount point listed on each disk. Defaults to $false.")] Boolean EnsureExchangeVolumeMountPointIsLast;
-    [Write, Description("")] Boolean CreateSubfolders; //Defaults to $false. If $true, specifies that DBNAME.db and DBNAME.log subfolders should be automatically created underneath the ExchangeDatabase mount points
-    [Write, ValueMap{"NTFS","REFS"}, Values{"NTFS","REFS"}, Description("")] String FileSystem; //The file system to use when formatting the volume. Defaults to NTFS.
-    [Write, Description("")] String MinDiskSize; //The minimum size of a disk to consider using. Defaults to none. Should be in a format like "1024MB" or "1TB".
-    [Write, ValueMap{"MBR","GPT"}, Values{"MBR","GPT"}, Description("")] String PartitioningScheme; //The partitioning scheme for the volume. Defaults to GPT.
-    [Write, Description("")] String UnitSize; //The unit size to use when formatting the disk. Defaults to 64k.
-    [Write, Description("")] String VolumePrefix; //The prefix to give to Exchange Volume folders. Defaults to EXVOL
+    [Write, Description("If $true, specifies that DBNAME.db and DBNAME.log subfolders should be automatically created underneath the ExchangeDatabase mount points. Defaults to $false.")] Boolean CreateSubfolders;
+    [Write, ValueMap{"NTFS","REFS"}, Values{"NTFS","REFS"}, Description("The file system to use when formatting the volume. Defaults to NTFS.")] String FileSystem;
+    [Write, Description("The minimum size of a disk to consider using. Defaults to none. Should be in a format like '1024MB' or '1TB'.")] String MinDiskSize;
+    [Write, ValueMap{"MBR","GPT"}, Values{"MBR","GPT"}, Description("The partitioning scheme for the volume. Defaults to GPT.")] String PartitioningScheme;
+    [Write, Description("The unit size to use when formatting the disk. Defaults to 64k.")] String UnitSize;
+    [Write, Description("The prefix to give to Exchange Volume folders. Defaults to EXVOL.")] String VolumePrefix;
 };
 
 

--- a/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.schema.mof
+++ b/DSCResources/MSFT_xExchAutoMountPoint/MSFT_xExchAutoMountPoint.schema.mof
@@ -2,18 +2,18 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchAutoMountPoint")]
 class MSFT_xExchAutoMountPoint : OMI_BaseResource
 {
-    [Key] String Identity; //The name of the server. Not actually used for anything
-    [Required] String AutoDagDatabasesRootFolderPath; //The parent folder for Exchange database mount point folders
-    [Required] String AutoDagVolumesRootFolderPath; //The parent folder for Exchange volume mount point folders
-    [Required] String DiskToDBMap[]; //An array of strings containing the databases for each disk. Databases on the same disk should be in the same string, and comma separated. Example: "DB1,DB2","DB3,DB4". This puts DB1 and DB2 on one disk, and DB3 and DB4 on another.
-    [Required] Uint32 SpareVolumeCount; //How many spare volumes will be available
-    [Write] Boolean EnsureExchangeVolumeMountPointIsLast;
-    [Write] Boolean CreateSubfolders; //Defaults to $false. If $true, specifies that DBNAME.db and DBNAME.log subfolders should be automatically created underneath the ExchangeDatabase mount points
-    [Write, ValueMap{"NTFS","REFS"}, Values{"NTFS","REFS"}] String FileSystem; //The file system to use when formatting the volume. Defaults to NTFS.
-    [Write] String MinDiskSize; //The minimum size of a disk to consider using. Defaults to none. Should be in a format like "1024MB" or "1TB".
-    [Write, ValueMap{"MBR","GPT"}, Values{"MBR","GPT"}] String PartitioningScheme; //The partitioning scheme for the volume. Defaults to GPT.
-    [Write] String UnitSize; //The unit size to use when formatting the disk. Defaults to 64k.
-    [Write] String VolumePrefix; //The prefix to give to Exchange Volume folders. Defaults to EXVOL
+    [Key, Description("The name of the server. Not actually used for anything.")] String Identity;
+    [Required, Description("The parent folder for Exchange database mount point folders.")] String AutoDagDatabasesRootFolderPath;
+    [Required, Description("The parent folder for Exchange volume mount point folders.")] String AutoDagVolumesRootFolderPath;
+    [Required, Description("An array of strings containing the databases for each disk. Databases on the same disk should be in the same string, and comma separated. Example: 'DB1,DB2','DB3,DB4'. This puts DB1 and DB2 on one disk, and DB3 and DB4 on another.")] String DiskToDBMap[];
+    [Required, Description("How many spare volumes will be available.")] Uint32 SpareVolumeCount;
+    [Write, Description("Whether the EXVOL mount point should be moved to be the last mount point listed on each disk. Defaults to $false.")] Boolean EnsureExchangeVolumeMountPointIsLast;
+    [Write, Description("")] Boolean CreateSubfolders; //Defaults to $false. If $true, specifies that DBNAME.db and DBNAME.log subfolders should be automatically created underneath the ExchangeDatabase mount points
+    [Write, ValueMap{"NTFS","REFS"}, Values{"NTFS","REFS"}, Description("")] String FileSystem; //The file system to use when formatting the volume. Defaults to NTFS.
+    [Write, Description("")] String MinDiskSize; //The minimum size of a disk to consider using. Defaults to none. Should be in a format like "1024MB" or "1TB".
+    [Write, ValueMap{"MBR","GPT"}, Values{"MBR","GPT"}, Description("")] String PartitioningScheme; //The partitioning scheme for the volume. Defaults to GPT.
+    [Write, Description("")] String UnitSize; //The unit size to use when formatting the disk. Defaults to 64k.
+    [Write, Description("")] String VolumePrefix; //The prefix to give to Exchange Volume folders. Defaults to EXVOL
 };
 
 

--- a/DSCResources/MSFT_xExchJetstressCleanup/MSFT_xExchJetstressCleanup.psm1
+++ b/DSCResources/MSFT_xExchJetstressCleanup/MSFT_xExchJetstressCleanup.psm1
@@ -128,17 +128,17 @@ function Set-TargetResource
     # Delete associated mount points if requested
     if ($DeleteAssociatedMountPoints -eq $true -and $ParentFoldersToRemove.Count -gt 0)
     {
-        $diskInfo = GetDiskInfo
+        $diskInfo = Get-DiskInfo
 
         foreach ($parent in $ParentFoldersToRemove.Keys)
         {
             if ($null -eq (Get-ChildItem -LiteralPath "$($parent)" -ErrorAction SilentlyContinue))
             {
-                $volNum = MountPointExists -Path "$($parent)" -DiskInfo $diskInfo
+                $volNum = Get-MountPointVolumeNumber -Path "$($parent)" -DiskInfo $diskInfo
 
                 if ($volNum -ge 0)
                 {
-                    StartDiskpart -Commands "select volume $($volNum)", "remove mount=`"$($parent)`"" -Verbose:$VerbosePreference | Out-Null
+                    Start-DiskPart -Commands "select volume $($volNum)", "remove mount=`"$($parent)`"" -Verbose:$VerbosePreference | Out-Null
 
                     RemoveFolder -Path "$($parent)"
                 }
@@ -264,7 +264,7 @@ function Test-TargetResource
         }
 
         # First make sure DB and log folders were cleaned up
-        $diskInfo = GetDiskInfo
+        $diskInfo = Get-DiskInfo
 
         foreach ($folder in $FoldersToRemove)
         {
@@ -273,7 +273,7 @@ function Test-TargetResource
             {
                 $parent = GetParentFolderFromString -Folder "$($folder)"
 
-                if ((MountPointExists -Path "$($parent)" -DiskInfo $diskInfo) -ge 0)
+                if ((Get-MountPointVolumeNumber -Path "$($parent)" -DiskInfo $diskInfo) -ge 0)
                 {
                     Write-Verbose -Message "Folder '$($parent)' still has a mount point associated with it."
                     $testResults = $false

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ parameters.
 * **EnsureExchangeVolumeMountPointIsLast**: Whether the EXVOL mount point
   should be moved to be the last mount point listed on each disk. Defaults
   to $false.
-* **CreateSubfolders**: Defaults to $false.
-  If $true, specifies that DBNAME.db and DBNAME.log subfolders should be
-  automatically created underneath the ExchangeDatabase mount points.
+* **CreateSubfolders**: If $true, specifies that DBNAME.db and DBNAME.log
+  subfolders should be automatically created underneath the ExchangeDatabase
+  mount points. Defaults to $false.
 * **FileSystem**: The file system to use when formatting the volume.
   Defaults to NTFS.
 * **MinDiskSize**: The minimum size of a disk to consider using. Defaults to none.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ parameters.
   Example: "DB1,DB2","DB3,DB4".
   This puts DB1 and DB2 on one disk, and DB3 and DB4 on another.
 * **SpareVolumeCount**: How many spare volumes will be available.
+* **EnsureExchangeVolumeMountPointIsLast**: Whether the EXVOL mount point
+  should be moved to be the last mount point listed on each disk. Defaults
+  to $false.
 * **CreateSubfolders**: Defaults to $false.
   If $true, specifies that DBNAME.db and DBNAME.log subfolders should be
   automatically created underneath the ExchangeDatabase mount points.

--- a/Tests/Unit/MSFT_xExchAutoMountPoint.tests.ps1
+++ b/Tests/Unit/MSFT_xExchAutoMountPoint.tests.ps1
@@ -52,8 +52,8 @@ try
 
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
-                Mock -CommandName GetDiskInfo -Verifiable -MockWith { return @{} }
-                Mock -CommandName GetDiskToDBMap -Verifiable -MockWith { return $getTargetResourceParams.DiskToDBMap }
+                Mock -CommandName Get-DiskInfo -Verifiable -MockWith { return @{} }
+                Mock -CommandName Get-DiskToDBMap -Verifiable -MockWith { return $getTargetResourceParams.DiskToDBMap }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }


### PR DESCRIPTION
#### Pull Request (PR) description
Rename poorly named functions in xExchangeDiskPart.psm1 and MSFT_xExchAutoMountPoint.psm1, and add comment based help.

#### This Pull Request (PR) fixes the following issues
-Fixes #285 
-Fixes #312 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
