### PR TITLE
Rename improperly named functions in MSFT_xExchClientAccessServer, MSFT_xExchDatabaseAvailabilityGroupNetwork, MSFT_xExchEcpVirtualDirectory, and MSFT_xExchExchangeCertificate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add support for Exchange Server 2019
 - Added additional parameters to the MSFT_xExchUMService resource
+- Rename improperly named functions, and add comment based help in
+  MSFT_xExchClientAccessServer, MSFT_xExchDatabaseAvailabilityGroupNetwork,
+  MSFT_xExchEcpVirtualDirectory, and MSFT_xExchExchangeCertificate.
 
 ## 1.25.0.0
 

--- a/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.psm1
+++ b/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.psm1
@@ -1,3 +1,46 @@
+<#
+    .SYNOPSIS
+        Retrieves the current DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The hostname of the Client Access Server.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AlternateServiceAccountCredential
+        The AlternateServiceAccountCredential parameter specifies an
+        alternative service account that'stypically used for Kerberos
+        authentication.
+
+    .PARAMETER AutoDiscoverServiceInternalUri
+        The AutoDiscoverServiceInternalUri parameter specifies the internal URL
+        of the Autodiscover service.
+
+    .PARAMETER AutoDiscoverSiteScope
+        The AutoDiscoverSiteScope parameter specifies the Active Directory site
+        that the Autodiscover service is authoritative for. Clients that
+        connect to the Autodiscover service by using the internal URL need to
+        exist in the specified site.
+
+    .PARAMETER CleanUpInvalidAlternateServiceAccountCredentials
+        The CleanUpInvalidAlternateServiceAccountCredentialsswitch specifies
+        whether to remove a previously configured alternate service account
+        that's no longer valid. You don't need to specify a value with this
+        switch.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER RemoveAlternateServiceAccountCredentials
+        The RemoveAlternateServiceAccountCredentialsswitch specifies whether to
+        remove a previously distributed alternate service account. You don't
+        need to specify a value with this switch.
+#>
 function Get-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -46,7 +89,7 @@ function Get-TargetResource
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-ClientAccessServ*' -Verbose:$VerbosePreference
 
-    $cas = GetClientAccessServer @PSBoundParameters
+    $cas = Get-ClientAccessServerInternal @PSBoundParameters
 
     if ($null -ne $cas)
     {
@@ -77,7 +120,49 @@ function Get-TargetResource
     $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the DSC configuration for this resource.
 
+    .PARAMETER Identity
+        The hostname of the Client Access Server.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AlternateServiceAccountCredential
+        The AlternateServiceAccountCredential parameter specifies an
+        alternative service account that'stypically used for Kerberos
+        authentication.
+
+    .PARAMETER AutoDiscoverServiceInternalUri
+        The AutoDiscoverServiceInternalUri parameter specifies the internal URL
+        of the Autodiscover service.
+
+    .PARAMETER AutoDiscoverSiteScope
+        The AutoDiscoverSiteScope parameter specifies the Active Directory site
+        that the Autodiscover service is authoritative for. Clients that
+        connect to the Autodiscover service by using the internal URL need to
+        exist in the specified site.
+
+    .PARAMETER CleanUpInvalidAlternateServiceAccountCredentials
+        The CleanUpInvalidAlternateServiceAccountCredentialsswitch specifies
+        whether to remove a previously configured alternate service account
+        that's no longer valid. You don't need to specify a value with this
+        switch.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER RemoveAlternateServiceAccountCredentials
+        The RemoveAlternateServiceAccountCredentialsswitch specifies whether to
+        remove a previously distributed alternate service account. You don't
+        need to specify a value with this switch.
+#>
 function Set-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -194,7 +279,50 @@ function Set-TargetResource
     & $setCasCmd @PSBoundParameters
 }
 
+<#
+    .SYNOPSIS
+        Tests whether the desired configuration for this resource has been
+        applied.
 
+    .PARAMETER Identity
+        The hostname of the Client Access Server.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AlternateServiceAccountCredential
+        The AlternateServiceAccountCredential parameter specifies an
+        alternative service account that'stypically used for Kerberos
+        authentication.
+
+    .PARAMETER AutoDiscoverServiceInternalUri
+        The AutoDiscoverServiceInternalUri parameter specifies the internal URL
+        of the Autodiscover service.
+
+    .PARAMETER AutoDiscoverSiteScope
+        The AutoDiscoverSiteScope parameter specifies the Active Directory site
+        that the Autodiscover service is authoritative for. Clients that
+        connect to the Autodiscover service by using the internal URL need to
+        exist in the specified site.
+
+    .PARAMETER CleanUpInvalidAlternateServiceAccountCredentials
+        The CleanUpInvalidAlternateServiceAccountCredentialsswitch specifies
+        whether to remove a previously configured alternate service account
+        that's no longer valid. You don't need to specify a value with this
+        switch.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER RemoveAlternateServiceAccountCredentials
+        The RemoveAlternateServiceAccountCredentialsswitch specifies whether to
+        remove a previously distributed alternate service account. You don't
+        need to specify a value with this switch.
+#>
 function Test-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -243,7 +371,7 @@ function Test-TargetResource
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-ClientAccessServ*' -Verbose:$VerbosePreference
 
-    $cas = GetClientAccessServer @PSBoundParameters
+    $cas = Get-ClientAccessServerInternal @PSBoundParameters
 
     $testResults = $true
 
@@ -269,11 +397,13 @@ function Test-TargetResource
         {
             $testResults = $false
         }
+
         if ($CleanUpInvalidAlternateServiceAccountCredentials)
         {
             Write-Verbose -Message 'CleanUpInvalidAlternateServiceAccountCredentials is set to $true. Forcing Test-TargetResource to return $false.'
             $testResults = $false
         }
+
         if ($RemoveAlternateServiceAccountCredentials -and ($cas.AlternateServiceAccountConfiguration.EffectiveCredentials.Count -gt 0))
         {
             Write-Verbose -Message 'RemoveAlternateServiceAccountCredentials is set to $true, and AlternateServiceAccountConfiguration currently has credentials configured. Returning $false.'
@@ -284,10 +414,55 @@ function Test-TargetResource
     return $testResults
 }
 
-# Runs Get-ClientAcccessServer, only specifying Identity, and optionally DomainController
-function GetClientAccessServer
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-ClientAccessServer. Runs
+        Get-ClientAcccessServer, only specifying Identity, and optionally
+        DomainController, and returns the results.
+
+    .PARAMETER Identity
+        The hostname of the Client Access Server.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AlternateServiceAccountCredential
+        The AlternateServiceAccountCredential parameter specifies an
+        alternative service account that'stypically used for Kerberos
+        authentication.
+
+    .PARAMETER AutoDiscoverServiceInternalUri
+        The AutoDiscoverServiceInternalUri parameter specifies the internal URL
+        of the Autodiscover service.
+
+    .PARAMETER AutoDiscoverSiteScope
+        The AutoDiscoverSiteScope parameter specifies the Active Directory site
+        that the Autodiscover service is authoritative for. Clients that
+        connect to the Autodiscover service by using the internal URL need to
+        exist in the specified site.
+
+    .PARAMETER CleanUpInvalidAlternateServiceAccountCredentials
+        The CleanUpInvalidAlternateServiceAccountCredentialsswitch specifies
+        whether to remove a previously configured alternate service account
+        that's no longer valid. You don't need to specify a value with this
+        switch.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER RemoveAlternateServiceAccountCredentials
+        The RemoveAlternateServiceAccountCredentialsswitch specifies whether to
+        remove a previously distributed alternate service account. You don't
+        need to specify a value with this switch.
+#>
+function Get-ClientAccessServerInternal
 {
     [CmdletBinding()]
+    [OutputType([System.Object])]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
+++ b/DSCResources/MSFT_xExchClientAccessServer/MSFT_xExchClientAccessServer.schema.mof
@@ -2,18 +2,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchClientAccessServer")]
 class MSFT_xExchClientAccessServer : OMI_BaseResource
 {
-    [Key] String Identity; //The hostname of the Client Access Server
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote PowerShell session to Exchange
-
-    //Remaining properties correspond directly to Set-ClientAccessServer parameters
-    //http://technet.microsoft.com/en-us/library/bb125157(v=exchg.150).aspx
-    [Write] String AutoDiscoverServiceInternalUri;
-    [Write] String AutoDiscoverSiteScope[];
-    [Write] String DomainController;
-    [Write, EmbeddedInstance("MSFT_Credential")] String AlternateServiceAccountCredential;
-    [Write] Boolean CleanUpInvalidAlternateServiceAccountCredentials;
-    [Write] Boolean RemoveAlternateServiceAccountCredentials;
+    [Key, Description("The hostname of the Client Access Server.")] String Identity;
+    [Required, Description("Credentials used to establish a remote PowerShell session to Exchange."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Write, Description("The AutoDiscoverServiceInternalUri parameter specifies the internal URL of the Autodiscover service.")] String AutoDiscoverServiceInternalUri;
+    [Write, Description("The AutoDiscoverSiteScope parameter specifies the Active Directory site that the Autodiscover service is authoritative for. Clients that connect to the Autodiscover service by using the internal URL need to exist in the specified site.")] String AutoDiscoverSiteScope[];
+    [Write, Description("The DomainController parameter specifies the domain controller that's used by this cmdlet to read data from or write data to Active Directory. You identify the domain controller by its fully qualified domain name (FQDN). For example, dc01.contoso.com.")] String DomainController;
+    [Write, Description("The AlternateServiceAccountCredential parameter specifies an alternative service account that'stypically used for Kerberos authentication."), EmbeddedInstance("MSFT_Credential")] String AlternateServiceAccountCredential;
+    [Write, Description("The CleanUpInvalidAlternateServiceAccountCredentialsswitch specifies whether to remove a previously configured alternate service account that's no longer valid.")] Boolean CleanUpInvalidAlternateServiceAccountCredentials;
+    [Write, Description("The RemoveAlternateServiceAccountCredentialsswitch specifies whether to remove a previously distributed alternate service account.")] Boolean RemoveAlternateServiceAccountCredentials;
 };
-
-
-

--- a/DSCResources/MSFT_xExchDatabaseAvailabilityGroupNetwork/MSFT_xExchDatabaseAvailabilityGroupNetwork.schema.mof
+++ b/DSCResources/MSFT_xExchDatabaseAvailabilityGroupNetwork/MSFT_xExchDatabaseAvailabilityGroupNetwork.schema.mof
@@ -2,18 +2,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchDatabaseAvailabilityGroupNetwork")]
 class MSFT_xExchDatabaseAvailabilityGroupNetwork : OMI_BaseResource
 {
-    [Key] String Name; //The name of the DAG network
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote PowerShell session to Exchange
-    [Required] String DatabaseAvailabilityGroup; //The DAG where the network will live
-    [Required, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure; //Whethe the DAG network should exist or not
-
-    //Remaining properties correspond directly to Set-DatabaseAvailabilityGroupNetwork parameters
-    //http://technet.microsoft.com/en-us/library/dd298008(v=exchg.150).aspx
-    [Write] String DomainController;
-    [Write] Boolean IgnoreNetwork;
-    [Write] Boolean ReplicationEnabled;
-    [Write] String Subnets[];
+    [Key, Description("The name of the DAG network.")] String Name;
+    [Required, Description("Credentials used to establish a remote PowerShell session to Exchange."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Required, Description("The DAG where the network will live.")] String DatabaseAvailabilityGroup;
+    [Required, Description("Whether the DAG network should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("The DomainController parameter specifies the domain controller that's used by this cmdlet to read data from or write data to Active Directory. You identify the domain controller by its fully qualified domain name (FQDN). For example, dc01.contoso.com.")] String DomainController;
+    [Write, Description("The IgnoreNetwork parameter indicates that the specified network should be ignored and not used by the DAG.")] Boolean IgnoreNetwork;
+    [Write, Description("The ReplicationEnabled parameter specifies whether the network can be used for replication activity. If this parameter isn't specified, the default behavior is to enable the network for replication.")] Boolean ReplicationEnabled;
+    [Write, Description("The Subnets parameter specifies one or more subnets that are associated with the DAG network.")] String Subnets[];
 };
-
-
-

--- a/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
@@ -16,7 +16,7 @@
     .PARAMETER AdminEnabled
         The AdminEnabled parameter specifies that the EAC isn't able to be
         accessed through the Internet. For more information, see Turn off
-        access to the Exchange admin center 
+        access to the Exchange admin center.
 
     .PARAMETER AdfsAuthentication
         The AdfsAuthentication parameter specifies that the ECP virtual
@@ -26,7 +26,7 @@
 
     .PARAMETER BasicAuthentication
         The BasicAuthentication parameter specifies whether Basic
-        authentication is enabled on the virtual directory. 
+        authentication is enabled on the virtual directory.
 
     .PARAMETER DigestAuthentication
         The DigestAuthentication parameter specifies whether Digest
@@ -174,7 +174,7 @@ function Get-TargetResource
     .PARAMETER AdminEnabled
         The AdminEnabled parameter specifies that the EAC isn't able to be
         accessed through the Internet. For more information, see Turn off
-        access to the Exchange admin center 
+        access to the Exchange admin center.
 
     .PARAMETER AdfsAuthentication
         The AdfsAuthentication parameter specifies that the ECP virtual
@@ -184,7 +184,7 @@ function Get-TargetResource
 
     .PARAMETER BasicAuthentication
         The BasicAuthentication parameter specifies whether Basic
-        authentication is enabled on the virtual directory. 
+        authentication is enabled on the virtual directory.
 
     .PARAMETER DigestAuthentication
         The DigestAuthentication parameter specifies whether Digest
@@ -329,7 +329,7 @@ function Set-TargetResource
     .PARAMETER AdminEnabled
         The AdminEnabled parameter specifies that the EAC isn't able to be
         accessed through the Internet. For more information, see Turn off
-        access to the Exchange admin center 
+        access to the Exchange admin center.
 
     .PARAMETER AdfsAuthentication
         The AdfsAuthentication parameter specifies that the ECP virtual
@@ -339,7 +339,7 @@ function Set-TargetResource
 
     .PARAMETER BasicAuthentication
         The BasicAuthentication parameter specifies whether Basic
-        authentication is enabled on the virtual directory. 
+        authentication is enabled on the virtual directory.
 
     .PARAMETER DigestAuthentication
         The DigestAuthentication parameter specifies whether Digest
@@ -536,7 +536,7 @@ function Test-TargetResource
     .PARAMETER AdminEnabled
         The AdminEnabled parameter specifies that the EAC isn't able to be
         accessed through the Internet. For more information, see Turn off
-        access to the Exchange admin center 
+        access to the Exchange admin center.
 
     .PARAMETER AdfsAuthentication
         The AdfsAuthentication parameter specifies that the ECP virtual
@@ -546,7 +546,7 @@ function Test-TargetResource
 
     .PARAMETER BasicAuthentication
         The BasicAuthentication parameter specifies whether Basic
-        authentication is enabled on the virtual directory. 
+        authentication is enabled on the virtual directory.
 
     .PARAMETER DigestAuthentication
         The DigestAuthentication parameter specifies whether Digest

--- a/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
+++ b/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.psm1
@@ -1,3 +1,68 @@
+<#
+    .SYNOPSIS
+        Retrieves the current DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The Identity of the ECP Virtual Directory.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to recycle the app pool after making changes. Defaults
+        to $true.
+
+    .PARAMETER AdminEnabled
+        The AdminEnabled parameter specifies that the EAC isn't able to be
+        accessed through the Internet. For more information, see Turn off
+        access to the Exchange admin center 
+
+    .PARAMETER AdfsAuthentication
+        The AdfsAuthentication parameter specifies that the ECP virtual
+        directory allows users to authenticate through Active Directory
+        Federation Services (AD FS) authentication. This parameter accepts
+        $true or $false. The default value is $false.
+
+    .PARAMETER BasicAuthentication
+        The BasicAuthentication parameter specifies whether Basic
+        authentication is enabled on the virtual directory. 
+
+    .PARAMETER DigestAuthentication
+        The DigestAuthentication parameter specifies whether Digest
+        authentication is enabled on the virtual directory.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalAuthenticationMethods
+        The ExternalAuthenticationMethods parameter specifies the
+        authentication methods supported on the Exchange server from outside
+        the firewall.
+
+    .PARAMETER ExternalUrl
+        The ExternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from outside the firewall.
+
+    .PARAMETER FormsAuthentication
+        The FormsAuthentication parameter specifies whether forms-based
+        authentication is enabled on the ECP virtual directory
+
+    .PARAMETER GzipLevel
+        The GzipLevel parameter sets Gzip configuration information for the
+        ECP virtual directory.
+
+    .PARAMETER InternalUrl
+        The InternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from inside the firewall.
+
+    .PARAMETER WindowsAuthentication
+        The WindowsAuthentication parameter specifies whether Integrated
+        Windows authentication is enabled on the virtual directory.
+#>
 function Get-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -69,7 +134,7 @@ function Get-TargetResource
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-EcpVirtualDirectory' -Verbose:$VerbosePreference
 
-    $EcpVdir = GetEcpVirtualDirectory @PSBoundParameters
+    $EcpVdir = Get-EcpVirtualDirectoryInternal @PSBoundParameters
 
     if ($null -ne $EcpVdir)
     {
@@ -91,6 +156,71 @@ function Get-TargetResource
     $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the DSC configuration for this resource.
+
+    .PARAMETER Identity
+        The Identity of the ECP Virtual Directory.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to recycle the app pool after making changes. Defaults
+        to $true.
+
+    .PARAMETER AdminEnabled
+        The AdminEnabled parameter specifies that the EAC isn't able to be
+        accessed through the Internet. For more information, see Turn off
+        access to the Exchange admin center 
+
+    .PARAMETER AdfsAuthentication
+        The AdfsAuthentication parameter specifies that the ECP virtual
+        directory allows users to authenticate through Active Directory
+        Federation Services (AD FS) authentication. This parameter accepts
+        $true or $false. The default value is $false.
+
+    .PARAMETER BasicAuthentication
+        The BasicAuthentication parameter specifies whether Basic
+        authentication is enabled on the virtual directory. 
+
+    .PARAMETER DigestAuthentication
+        The DigestAuthentication parameter specifies whether Digest
+        authentication is enabled on the virtual directory.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalAuthenticationMethods
+        The ExternalAuthenticationMethods parameter specifies the
+        authentication methods supported on the Exchange server from outside
+        the firewall.
+
+    .PARAMETER ExternalUrl
+        The ExternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from outside the firewall.
+
+    .PARAMETER FormsAuthentication
+        The FormsAuthentication parameter specifies whether forms-based
+        authentication is enabled on the ECP virtual directory
+
+    .PARAMETER GzipLevel
+        The GzipLevel parameter sets Gzip configuration information for the
+        ECP virtual directory.
+
+    .PARAMETER InternalUrl
+        The InternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from inside the firewall.
+
+    .PARAMETER WindowsAuthentication
+        The WindowsAuthentication parameter specifies whether Integrated
+        Windows authentication is enabled on the virtual directory.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -180,6 +310,72 @@ function Set-TargetResource
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests whether the desired configuration for this resource has been
+        applied.
+
+    .PARAMETER Identity
+        The Identity of the ECP Virtual Directory.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to recycle the app pool after making changes. Defaults
+        to $true.
+
+    .PARAMETER AdminEnabled
+        The AdminEnabled parameter specifies that the EAC isn't able to be
+        accessed through the Internet. For more information, see Turn off
+        access to the Exchange admin center 
+
+    .PARAMETER AdfsAuthentication
+        The AdfsAuthentication parameter specifies that the ECP virtual
+        directory allows users to authenticate through Active Directory
+        Federation Services (AD FS) authentication. This parameter accepts
+        $true or $false. The default value is $false.
+
+    .PARAMETER BasicAuthentication
+        The BasicAuthentication parameter specifies whether Basic
+        authentication is enabled on the virtual directory. 
+
+    .PARAMETER DigestAuthentication
+        The DigestAuthentication parameter specifies whether Digest
+        authentication is enabled on the virtual directory.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalAuthenticationMethods
+        The ExternalAuthenticationMethods parameter specifies the
+        authentication methods supported on the Exchange server from outside
+        the firewall.
+
+    .PARAMETER ExternalUrl
+        The ExternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from outside the firewall.
+
+    .PARAMETER FormsAuthentication
+        The FormsAuthentication parameter specifies whether forms-based
+        authentication is enabled on the ECP virtual directory
+
+    .PARAMETER GzipLevel
+        The GzipLevel parameter sets Gzip configuration information for the
+        ECP virtual directory.
+
+    .PARAMETER InternalUrl
+        The InternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from inside the firewall.
+
+    .PARAMETER WindowsAuthentication
+        The WindowsAuthentication parameter specifies whether Integrated
+        Windows authentication is enabled on the virtual directory.
+#>
 function Test-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -254,7 +450,7 @@ function Test-TargetResource
     # Ensure an empty string is $null and not a string
     Set-EmptyStringParamsToNull -PSBoundParametersIn $PSBoundParameters
 
-    $EcpVdir = GetEcpVirtualDirectory @PSBoundParameters
+    $EcpVdir = Get-EcpVirtualDirectoryInternal @PSBoundParameters
 
     $testResults = $true
 
@@ -320,9 +516,77 @@ function Test-TargetResource
     return $testResults
 }
 
-function GetEcpVirtualDirectory
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-EcpVirtualDirectory. Runs
+        Get-EcpVirtualDirectory, only specifying Identity, and optionally
+        DomainController, and returns the results.
+
+    .PARAMETER Identity
+        The Identity of the ECP Virtual Directory.
+
+    .PARAMETER Credential
+        The Credentials to use when creating a remote PowerShell session to
+        Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to recycle the app pool after making changes. Defaults
+        to $true.
+
+    .PARAMETER AdminEnabled
+        The AdminEnabled parameter specifies that the EAC isn't able to be
+        accessed through the Internet. For more information, see Turn off
+        access to the Exchange admin center 
+
+    .PARAMETER AdfsAuthentication
+        The AdfsAuthentication parameter specifies that the ECP virtual
+        directory allows users to authenticate through Active Directory
+        Federation Services (AD FS) authentication. This parameter accepts
+        $true or $false. The default value is $false.
+
+    .PARAMETER BasicAuthentication
+        The BasicAuthentication parameter specifies whether Basic
+        authentication is enabled on the virtual directory. 
+
+    .PARAMETER DigestAuthentication
+        The DigestAuthentication parameter specifies whether Digest
+        authentication is enabled on the virtual directory.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalAuthenticationMethods
+        The ExternalAuthenticationMethods parameter specifies the
+        authentication methods supported on the Exchange server from outside
+        the firewall.
+
+    .PARAMETER ExternalUrl
+        The ExternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from outside the firewall.
+
+    .PARAMETER FormsAuthentication
+        The FormsAuthentication parameter specifies whether forms-based
+        authentication is enabled on the ECP virtual directory
+
+    .PARAMETER GzipLevel
+        The GzipLevel parameter sets Gzip configuration information for the
+        ECP virtual directory.
+
+    .PARAMETER InternalUrl
+        The InternalURL parameter specifies the URL that's used to connect to
+        the virtual directory from inside the firewall.
+
+    .PARAMETER WindowsAuthentication
+        The WindowsAuthentication parameter specifies whether Integrated
+        Windows authentication is enabled on the virtual directory.
+#>
+function Get-EcpVirtualDirectoryInternal
 {
     [CmdletBinding()]
+    [OutputType([System.Object])]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.schema.mof
+++ b/DSCResources/MSFT_xExchEcpVirtualDirectory/MSFT_xExchEcpVirtualDirectory.schema.mof
@@ -2,24 +2,18 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchEcpVirtualDirectory")]
 class MSFT_xExchEcpVirtualDirectory : OMI_BaseResource
 {
-    [Key] String Identity; //The Identity of the ECP Virtual Directory
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote PowerShell session to Exchange
-    [Write] Boolean AllowServiceRestart; //Whether it is OK to recycle the app pool after making changes. Defaults to $true.
-
-    //Remaining properties correspond directly to Set-EcpVirtualDirectory parameters
-    //http://technet.microsoft.com/en-us/library/dd297991(v=exchg.150).aspx
-    [Write] Boolean AdfsAuthentication;
-    [Write] Boolean AdminEnabled;
-    [Write] Boolean BasicAuthentication;
-    [Write] Boolean DigestAuthentication;
-    [Write] String DomainController;
-    [Write] String ExternalAuthenticationMethods[];
-    [Write] Boolean FormsAuthentication;
-    [Write, ValueMap{"Off", "Low", "High", "Error"}, Values{"Off", "Low", "High", "Error"}] String GzipLevel;
-    [Write] String ExternalUrl;
-    [Write] String InternalUrl;
-    [Write] Boolean WindowsAuthentication;
+    [Key, Description("The Identity of the ECP Virtual Directory.")] String Identity;
+    [Required, Description("Credentials used to establish a remote PowerShell session to Exchange."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Write, Description("Whether it is OK to recycle the app pool after making changes. Defaults to $true.")] Boolean AllowServiceRestart;
+    [Write, Description("The AdfsAuthentication parameter specifies that the ECP virtual directory allows users to authenticate through Active Directory Federation Services (AD FS) authentication. This parameter accepts $true or $false. The default value is $false.")] Boolean AdfsAuthentication;
+    [Write, Description("The AdminEnabled parameter specifies that the EAC isn't able to be accessed through the Internet.")] Boolean AdminEnabled;
+    [Write, Description("The BasicAuthentication parameter specifies whether Basic authentication is enabled on the virtual directory. ")] Boolean BasicAuthentication;
+    [Write, Description("The DigestAuthentication parameter specifies whether Digest authentication is enabled on the virtual directory.")] Boolean DigestAuthentication;
+    [Write, Description("The DomainController parameter specifies the domain controller that's used by this cmdlet to read data from or write data to Active Directory. You identify the domain controller by its fully qualified domain name (FQDN). For example, dc01.contoso.com.")] String DomainController;
+    [Write, Description("The ExternalAuthenticationMethods parameter specifies the authentication methods supported on the Exchange server from outside the firewall.")] String ExternalAuthenticationMethods[];
+    [Write, Description("The FormsAuthentication parameter specifies whether forms-based authentication is enabled on the ECP virtual directory.")] Boolean FormsAuthentication;
+    [Write, Description("The GzipLevel parameter sets Gzip configuration information for the ECP virtual directory."), ValueMap{"Off", "Low", "High", "Error"}, Values{"Off", "Low", "High", "Error"}] String GzipLevel;
+    [Write, Description("The ExternalURL parameter specifies the URL that's used to connect to the virtual directory from outside the firewall.")] String ExternalUrl;
+    [Write, Description("The InternalURL parameter specifies the URL that's used to connect to the virtual directory from inside the firewall.")] String InternalUrl;
+    [Write, Description("The WindowsAuthentication parameter specifies whether Integrated Windows authentication is enabled on the virtual directory.")] Boolean WindowsAuthentication;
 };
-
-
-

--- a/DSCResources/MSFT_xExchExchangeCertificate/MSFT_xExchExchangeCertificate.schema.mof
+++ b/DSCResources/MSFT_xExchExchangeCertificate/MSFT_xExchExchangeCertificate.schema.mof
@@ -2,15 +2,12 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchExchangeCertificate")]
 class MSFT_xExchExchangeCertificate : OMI_BaseResource
 {
-    [Key] String Thumbprint; //Thumbprint of the certificate to work on
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote PowerShell session to Exchange
-    [Required, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure; //Whether the certificate should be present or not
-    [Write] Boolean AllowExtraServices; //Get-ExchangeCertificate sometimes displays more services than are actually enabled. Setting this to true allows tests to pass in that situation as long as the requested services are present.
-    [Write, EmbeddedInstance("MSFT_Credential")] String CertCreds; //Credentials containing the password to the .pfx file in CertFilePath
-    [Write] String CertFilePath; //The file path to the certificate .pfx file that should be imported
-    [Write] String DomainController; //Domain Controller to talk to
-    [Write] String Services[]; //Services to enable on the certificate. See: http://technet.microsoft.com/en-us/library/aa997231(v=exchg.150).aspx
+    [Key, Description("Thumbprint of the certificate to work on.")] String Thumbprint;
+    [Required, Description("Credentials used to establish a remote PowerShell session to Exchange."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Required, Description("Whether the certificate should be present or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Get-ExchangeCertificate sometimes displays more services than are actually enabled. Setting this to true allows tests to pass in that situation as long as the requested services are present.")] Boolean AllowExtraServices;
+    [Write, Description("Credentials containing the password to the .pfx file in CertFilePath."), EmbeddedInstance("MSFT_Credential")] String CertCreds;
+    [Write, Description("The file path to the certificate .pfx file that should be imported.")] String CertFilePath;
+    [Write, Description("The DomainController parameter specifies the domain controller that's used by this cmdlet to read data from or write data to Active Directory. You identify the domain controller by its fully qualified domain name (FQDN). For example, dc01.contoso.com.")] String DomainController;
+    [Write, Description("The Services parameter specifies the Exchange services that the certificate is enabled for.")] String Services[];
 };
-
-
-

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Where no description is listed, properties correspond directly to
 [Set-ClientAccessService](https://docs.microsoft.com/en-us/powershell/module/exchange/client-access-servers/set-clientaccessservice)
 parameters.
 
-* **Identity**: The Identity of the Autodiscover Virtual Directory.
+* **Identity**: The hostname of the Client Access Server.
 * **Credential**: Credentials used to establish a remote PowerShell session to Exchange.
 * **AutoDiscoverServiceInternalUri**
 * **AutoDiscoverSiteScope**

--- a/Tests/Unit/MSFT_xExchClientAccessServer.tests.ps1
+++ b/Tests/Unit/MSFT_xExchClientAccessServer.tests.ps1
@@ -67,7 +67,7 @@ try
             Mock -CommandName Get-RemoteExchangeSession -Verifiable
 
             Context 'When Get-TargetResource is called' {
-                Mock -CommandName GetClientAccessServer -Verifiable -MockWith { return $getClientAccessServerStandardOutput }
+                Mock -CommandName Get-ClientAccessServerInternal -Verifiable -MockWith { return $getClientAccessServerStandardOutput }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }
@@ -76,7 +76,7 @@ try
                 It 'Should try to convert AutoDiscoverSiteScope to an array' {
                     $siteScopeOut = @('Site1','Site2')
 
-                    Mock -CommandName GetClientAccessServer -Verifiable -MockWith {
+                    Mock -CommandName Get-ClientAccessServerInternal -Verifiable -MockWith {
                         $siteScopeVar = New-Object -TypeName PSObject
 
                         Add-Member -MemberType ScriptMethod -InputObject $siteScopeVar -Name 'ToArray' -Value { return @('Site1','Site2') }

--- a/Tests/Unit/MSFT_xExchDatabaseAvailabilityGroupNetwork.tests.ps1
+++ b/Tests/Unit/MSFT_xExchDatabaseAvailabilityGroupNetwork.tests.ps1
@@ -61,7 +61,7 @@ try
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
                 Mock -CommandName Get-RemoteExchangeSession -Verifiable
-                Mock -CommandName GetDatabaseAvailabilityGroupNetwork -Verifiable -MockWith { return $getDatabaseAvailabilityGroupNetworkStandardOutput }
+                Mock -CommandName Get-DatabaseAvailabilityGroupNetworkInternal -Verifiable -MockWith { return $getDatabaseAvailabilityGroupNetworkStandardOutput }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }

--- a/Tests/Unit/MSFT_xExchEcpVirtualDirectory.tests.ps1
+++ b/Tests/Unit/MSFT_xExchEcpVirtualDirectory.tests.ps1
@@ -63,7 +63,7 @@ try
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
                 Mock -CommandName Get-RemoteExchangeSession -Verifiable
-                Mock -CommandName GetEcpVirtualDirectory -Verifiable -MockWith { return $getEcpVirtualDirectoryStandardOutput }
+                Mock -CommandName Get-EcpVirtualDirectoryInternal -Verifiable -MockWith { return $getEcpVirtualDirectoryStandardOutput }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }

--- a/Tests/Unit/MSFT_xExchExchangeCertificate.tests.ps1
+++ b/Tests/Unit/MSFT_xExchExchangeCertificate.tests.ps1
@@ -55,7 +55,7 @@ try
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
                 Mock -CommandName Get-RemoteExchangeSession -Verifiable
-                Mock -CommandName GetExchangeCertificate -Verifiable -MockWith { return $getExchangeCertificateStandardOutput }
+                Mock -CommandName Get-ExchangeCertificateInternal -Verifiable -MockWith { return $getExchangeCertificateStandardOutput }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }


### PR DESCRIPTION
#### Pull Request (PR) description
Rename improperly named functions, and add comment based help in MSFT_xExchClientAccessServer, MSFT_xExchDatabaseAvailabilityGroupNetwork, MSFT_xExchEcpVirtualDirectory, and MSFT_xExchExchangeCertificate.

#### This Pull Request (PR) fixes the following issues
- Fixes #286 
- Fixes #288 
- Fixes #289 
- Fixes #290

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/344)
<!-- Reviewable:end -->
