### PR TITLE
MSFT_xExchImapSettings: Rename improperly named functions, and add comment based help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Added additional parameters to the MSFT_xExchUMService resource
 - Rename improperly named functions, and add comment based help in
   MSFT_xExchClientAccessServer, MSFT_xExchDatabaseAvailabilityGroupNetwork,
-  MSFT_xExchEcpVirtualDirectory, and MSFT_xExchExchangeCertificate.
+  MSFT_xExchEcpVirtualDirectory, MSFT_xExchExchangeCertificate,
+  MSFT_xExchImapSettings.
 - Added additional parameters to the MSFT_xExchUMCallRouterSettings resource
 - Rename improper function names in MSFT_xExchDatabaseAvailabilityGroup,
   MSFT_xExchJetstress, MSFT_xExchJetstressCleanup, MSFT_xExchMailboxDatabase,

--- a/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.psm1
+++ b/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.psm1
@@ -1,3 +1,36 @@
+<#
+    .SYNOPSIS
+        Retrieves the current DSC configuration for this resource.
+
+    .PARAMETER Server
+        The IMAP server to configure.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote PowerShell session to Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to restart the IMAP services after making changes.
+        Defaults to $false.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalConnectionSettings
+        The ExternalConnectionSettings parameter specifies the host name, port,
+        and encryption method that's used by external IMAP4 clients (IMAP4
+        connections from outside your corporate network).
+
+    .PARAMETER LoginType
+        The LoginType parameter specifies the authentication method for IMAP4
+        connections.
+
+    .PARAMETER X509CertificateName
+        The X509CertificateName parameter specifies the certificate that's used
+        for encrypting IMAP4 client connections.
+#>
 function Get-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -23,13 +56,13 @@ function Get-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [Parameter()]
         [ValidateSet('PlainTextLogin', 'PlainTextAuthentication', 'SecureLogin')]
         [System.String]
         $LoginType,
-
-        [Parameter()]
-        [System.String[]]
-        $ExternalConnectionSettings,
 
         [Parameter()]
         [System.String]
@@ -41,7 +74,7 @@ function Get-TargetResource
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-ImapSettings' -Verbose:$VerbosePreference
 
-    $imap = GetImapSettings @PSBoundParameters
+    $imap = Get-ImapSettingsInternal @PSBoundParameters
 
     if ($null -ne $imap)
     {
@@ -56,6 +89,39 @@ function Get-TargetResource
     $returnValue
 }
 
+<#
+    .SYNOPSIS
+        Sets the DSC configuration for this resource.
+
+    .PARAMETER Server
+        The IMAP server to configure.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote PowerShell session to Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to restart the IMAP services after making changes.
+        Defaults to $false.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalConnectionSettings
+        The ExternalConnectionSettings parameter specifies the host name, port,
+        and encryption method that's used by external IMAP4 clients (IMAP4
+        connections from outside your corporate network).
+
+    .PARAMETER LoginType
+        The LoginType parameter specifies the authentication method for IMAP4
+        connections.
+
+    .PARAMETER X509CertificateName
+        The X509CertificateName parameter specifies the certificate that's used
+        for encrypting IMAP4 client connections.
+#>
 function Set-TargetResource
 {
     [CmdletBinding()]
@@ -79,13 +145,13 @@ function Set-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [Parameter()]
         [ValidateSet('PlainTextLogin', 'PlainTextAuthentication', 'SecureLogin')]
         [System.String]
         $LoginType,
-
-        [Parameter()]
-        [System.String[]]
-        $ExternalConnectionSettings,
 
         [Parameter()]
         [System.String]
@@ -113,6 +179,40 @@ function Set-TargetResource
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests whether the desired configuration for this resource has been
+        applied.
+
+    .PARAMETER Server
+        The IMAP server to configure.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote PowerShell session to Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to restart the IMAP services after making changes.
+        Defaults to $false.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalConnectionSettings
+        The ExternalConnectionSettings parameter specifies the host name, port,
+        and encryption method that's used by external IMAP4 clients (IMAP4
+        connections from outside your corporate network).
+
+    .PARAMETER LoginType
+        The LoginType parameter specifies the authentication method for IMAP4
+        connections.
+
+    .PARAMETER X509CertificateName
+        The X509CertificateName parameter specifies the certificate that's used
+        for encrypting IMAP4 client connections.
+#>
 function Test-TargetResource
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -138,13 +238,13 @@ function Test-TargetResource
         $DomainController,
 
         [Parameter()]
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [Parameter()]
         [ValidateSet('PlainTextLogin', 'PlainTextAuthentication', 'SecureLogin')]
         [System.String]
         $LoginType,
-
-        [Parameter()]
-        [System.String[]]
-        $ExternalConnectionSettings,
 
         [Parameter()]
         [System.String]
@@ -158,7 +258,7 @@ function Test-TargetResource
 
     Set-EmptyStringParamsToNull -PSBoundParametersIn $PSBoundParameters
 
-    $imap = GetImapSettings @PSBoundParameters
+    $imap = Get-ImapSettingsInternal @PSBoundParameters
 
     $testResults = $true
 
@@ -189,7 +289,42 @@ function Test-TargetResource
     return $testResults
 }
 
-function GetImapSettings
+<#
+    .SYNOPSIS
+        Used as a wrapper for Get-ImapSettings. Runs
+        Get-ImapSettings, only specifying Server, and
+        optionally DomainController, and returns the results.
+
+    .PARAMETER Server
+        The IMAP server to configure.
+
+    .PARAMETER Credential
+        Credentials used to establish a remote PowerShell session to Exchange.
+
+    .PARAMETER AllowServiceRestart
+        Whether it is OK to restart the IMAP services after making changes.
+        Defaults to $false.
+
+    .PARAMETER DomainController
+        The DomainController parameter specifies the domain controller that's
+        used by this cmdlet to read data from or write data to Active
+        Directory. You identify the domain controller by its fully qualified
+        domain name (FQDN). For example, dc01.contoso.com.
+
+    .PARAMETER ExternalConnectionSettings
+        The ExternalConnectionSettings parameter specifies the host name, port,
+        and encryption method that's used by external IMAP4 clients (IMAP4
+        connections from outside your corporate network).
+
+    .PARAMETER LoginType
+        The LoginType parameter specifies the authentication method for IMAP4
+        connections.
+
+    .PARAMETER X509CertificateName
+        The X509CertificateName parameter specifies the certificate that's used
+        for encrypting IMAP4 client connections.
+#>
+function Get-ImapSettingsInternal
 {
     [CmdletBinding()]
     param
@@ -212,13 +347,13 @@ function GetImapSettings
         $DomainController,
 
         [Parameter()]
+        [System.String[]]
+        $ExternalConnectionSettings,
+
+        [Parameter()]
         [ValidateSet('PlainTextLogin', 'PlainTextAuthentication', 'SecureLogin')]
         [System.String]
         $LoginType,
-
-        [Parameter()]
-        [System.String[]]
-        $ExternalConnectionSettings,
 
         [Parameter()]
         [System.String]

--- a/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.schema.mof
+++ b/DSCResources/MSFT_xExchImapSettings/MSFT_xExchImapSettings.schema.mof
@@ -2,14 +2,11 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xExchImapSettings")]
 class MSFT_xExchImapSettings : OMI_BaseResource
 {
-    [Key] String Server; //The IMAP server to configure
-    [Required, EmbeddedInstance("MSFT_Credential")] String Credential; //Credentials used to establish a remote PowerShell session to Exchange
-    [Write] Boolean AllowServiceRestart; //Whether it is OK to restart the IMAP services after making changes. Defaults to $false.
-    [Write] String DomainController; //Optional Domain Controller to connect to
-    [Write, ValueMap{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}, Values{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}] String LoginType; //The LoginType to be used for IMAP
-    [Write] String ExternalConnectionSettings[]; //Specifies the host name, port, and encryption type that Exchange uses when IMAP clients connect to their email from the outside
-    [Write] String X509CertificateName; //Specifies the host name in the SSL certificate from the Associated Subject field.
+    [Key, Description("The IMAP server to configure.")] String Server;
+    [Required, Description("Credentials used to establish a remote PowerShell session to Exchange."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Write, Description("Whether it is OK to restart the IMAP services after making changes. Defaults to $false.")] Boolean AllowServiceRestart;
+    [Write, Description("The DomainController parameter specifies the domain controller that's used by this cmdlet to read data from or write data to Active Directory. You identify the domain controller by its fully qualified domain name (FQDN). For example, dc01.contoso.com.")] String DomainController; //Optional Domain Controller to connect to
+    [Write, Description("The ExternalConnectionSettings parameter specifies the host name, port, and encryption method that's used by external IMAP4 clients (IMAP4 connections from outside your corporate network).")] String ExternalConnectionSettings[];
+    [Write, Description("The LoginType parameter specifies the authentication method for IMAP4 connections."), ValueMap{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}, Values{"PlainTextLogin","PlainTextAuthentication","SecureLogin"}] String LoginType;
+    [Write, Description("The X509CertificateName parameter specifies the certificate that's used for encrypting IMAP4 client connections.")] String X509CertificateName;
 };
-
-
-

--- a/README.md
+++ b/README.md
@@ -480,20 +480,26 @@ parameters.
 
 **xExchImapSettings** configures IMAP settings using Set-ImapSettings.
 
-Most properties correspond directly to
+Most properties correspond directly to properties in
 [Set-ImapSettings](https://docs.microsoft.com/en-us/powershell/module/exchange/client-access/set-imapsettings)
 parameters.
 
 * **Server**: Hostname of the IMAP server to configure.
-* **Credential**: Credentials used to establish a remote PowerShell session to Exchange.
+* **Credential**: Credentials used to establish a remote PowerShell session to
+  Exchange.
 * **AllowServiceRestart**: Whether it is OK to restart the IMAP services after
   making changes. Defaults to $false.
-* **DomainController**: Optional Domain Controller to connect to.
-* **ExternalConnectionSettings**: Specifies the host name, port, and encryption
-  type that Exchange uses when IMAP clients connect to their email from the outside.
-* **LoginType**: The LoginType to be used for IMAP.
-* **X509CertificateName**: Specifies the host name in the SSL certificate
-  from the Associated Subject field.
+* **DomainController**: The DomainController parameter specifies the domain
+  controller that's used by this cmdlet to read data from or write data to
+  Active Directory. You identify the domain controller by its fully qualified
+  domain name (FQDN). For example, dc01.contoso.com.
+* **ExternalConnectionSettings**: The ExternalConnectionSettings parameter
+  specifies the host name, port, and encryption method that's used by external
+  IMAP4 clients (IMAP4 connections from outside your corporate network).
+* **LoginType**: The LoginType parameter specifies the authentication method
+  for IMAP4 connections.
+* **X509CertificateName**: The X509CertificateName parameter specifies the
+  certificate that's used for encrypting IMAP4 client connections.
 
 ### xExchInstall
 

--- a/Tests/Unit/MSFT_xExchImapSettings.tests.ps1
+++ b/Tests/Unit/MSFT_xExchImapSettings.tests.ps1
@@ -56,7 +56,7 @@ try
             Context 'When Get-TargetResource is called' {
                 Mock -CommandName Write-FunctionEntry -Verifiable
                 Mock -CommandName Get-RemoteExchangeSession -Verifiable
-                Mock -CommandName GetImapSettings -Verifiable -MockWith { return $getImapSettingsStandardOutput }
+                Mock -CommandName Get-ImapSettingsInternal -Verifiable -MockWith { return $getImapSettingsStandardOutput }
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }


### PR DESCRIPTION
#### Pull Request (PR) description
Rename improperly named functions, and add comment based help

#### This Pull Request (PR) fixes the following issues
- Fixes #293 
- Fixes #347 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/397)
<!-- Reviewable:end -->
