### PR TITLE
MSFT_xExchMailboxDatabase: Fix bug with the DataMoveReplicationConstraint parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added additional parameters to the MSFT_xExchTransportService resource
 - Added additional parameters to the MSFT_xExchEcpVirtualDirectory resource
 - Added additional unit tests to the MSFT_xExchAutodiscoverVirutalDirectory resource
+- MSFT_xExchMailboxDatabase: Fixes issue with DataMoveReplicationConstraint
+  parameter (#401)
 
 ## 1.26.0.0
 

--- a/DSCResources/MSFT_xExchMailboxDatabase/MSFT_xExchMailboxDatabase.psm1
+++ b/DSCResources/MSFT_xExchMailboxDatabase/MSFT_xExchMailboxDatabase.psm1
@@ -607,7 +607,7 @@ function Test-TargetResource
                 $testResults = $false
             }
 
-            if (!(Test-ExchangeSetting -Name 'DataMoveReplicationConstraint' -Type 'Boolean' -ExpectedValue $DataMoveReplicationConstraint -ActualValue $db.DataMoveReplicationConstraint -PSBoundParametersIn $PSBoundParameters -Verbose:$VerbosePreference))
+            if (!(Test-ExchangeSetting -Name 'DataMoveReplicationConstraint' -Type 'String' -ExpectedValue $DataMoveReplicationConstraint -ActualValue $db.DataMoveReplicationConstraint -PSBoundParametersIn $PSBoundParameters -Verbose:$VerbosePreference))
             {
                 $testResults = $false
             }

--- a/Tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
@@ -89,6 +89,7 @@ if ($exchangeInstalled)
             CalendarLoggingQuota = 'unlimited'
             CircularLoggingEnabled = $true
             DatabaseCopyCount = 1
+            DataMoveReplicationConstraint = 'None'
             DeletedItemRetention = '14.00:00:00'
             EventHistoryRetentionPeriod = '03:04:05'
             IndexEnabled = $true
@@ -116,6 +117,7 @@ if ($exchangeInstalled)
             CalendarLoggingQuota = 'unlimited'
             CircularLoggingEnabled = $true
             DatabaseCopyCount = 1
+            DataMoveReplicationConstraint = 'None'
             DeletedItemRetention = '14.00:00:00'
             EventHistoryRetentionPeriod = '03:04:05'
             IndexEnabled = $true


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes the bug with the DataMoveReplicationConstraint parameter in MSFT_xExchMailboxDatabase

#### This Pull Request (PR) fixes the following issues
-Fixes #401 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/404)
<!-- Reviewable:end -->
