### PR TITLE
Enable Default PSSCript Rules 

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -4,9 +4,9 @@
         cloned. It is automatically cloned as soon as any unit or
         integration tests are run.
     #>
-    CustomRulePath = '.\DSCResource.Tests\DscResource.AnalyzerRules'
+    CustomRulePath      = '.\DSCResource.Tests\DscResource.AnalyzerRules'
 
-    IncludeRules   = @(
+    IncludeRules        = @(
         # DSC Resource Kit style guideline rules.
         'PSAvoidDefaultValueForMandatoryParameter',
         'PSAvoidDefaultValueSwitchParameter',
@@ -50,4 +50,6 @@
         #>
         'Measure-*'
     )
+
+    IncludeDefaultRules = $true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enable Script Analyzer default rules
+
 ## 1.28.0.0
 
 - Added MSFT_xExchFrontendTransportService resource, based on


### PR DESCRIPTION
#### Pull Request (PR) description

I have noticed that the default rules for PSScriptAnalyzer were not enabled, although a bunch of them are part of IncludeRules array.
Adding following line in analyzersettings.psd1 would enable them:
IncludeDefaultRules = $true

#### This Pull Request (PR) fixes the following issues

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/419)
<!-- Reviewable:end -->
