### PR TITLE
MSFT_xExchDatabaseAvailabilityGroup: Add AutoDAGBitlockerEnabled support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Enable Script Analyzer default rules
+- Add the AutoDagBitlockerEnabled parameter to DSC resource MSFT_xExchDatabaseAvailabilityGroup
 
 ## 1.28.0.0
 

--- a/DSCResources/MSFT_xExchDatabaseAvailabilityGroup/MSFT_xExchDatabaseAvailabilityGroup.psm1
+++ b/DSCResources/MSFT_xExchDatabaseAvailabilityGroup/MSFT_xExchDatabaseAvailabilityGroup.psm1
@@ -28,6 +28,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AutoDagBitlockerEnabled,
+
+        [Parameter()]
+        [System.Boolean]
         $AutoDagAutoRedistributeEnabled,
 
         [Parameter()]
@@ -115,7 +119,7 @@ function Get-TargetResource
         $WitnessServer
     )
 
-    Write-FunctionEntry -Parameters @{'Name' = $Name} -Verbose:$VerbosePreference
+    Write-FunctionEntry -Parameters @{'Name' = $Name } -Verbose:$VerbosePreference
 
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
@@ -128,6 +132,7 @@ function Get-TargetResource
             Name                                 = [System.String] $Name
             AlternateWitnessDirectory            = [System.String] $dag.AlternateWitnessDirectory
             AlternateWitnessServer               = [System.String] $dag.AlternateWitnessServer
+            AutoDagBitlockerEnabled              = [System.Boolean] $dag.AutoDagBitlockerEnabled
             AutoDagAutoReseedEnabled             = [System.Boolean] $dag.AutoDagAutoReseedEnabled
             AutoDagDatabaseCopiesPerDatabase     = [System.Int32] $dag.AutoDagDatabaseCopiesPerDatabase
             AutoDagDatabaseCopiesPerVolume       = [System.Int32] $dag.AutoDagDatabaseCopiesPerVolume
@@ -189,6 +194,10 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AutoDagBitlockerEnabled,
+
+        [Parameter()]
+        [System.Boolean]
         $AutoDagAutoRedistributeEnabled,
 
         [Parameter()]
@@ -276,7 +285,7 @@ function Set-TargetResource
         $WitnessServer
     )
 
-    Write-FunctionEntry -Parameters @{'Name' = $Name} -Verbose:$VerbosePreference
+    Write-FunctionEntry -Parameters @{'Name' = $Name } -Verbose:$VerbosePreference
 
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup', 'Set-DatabaseAvailabilityGroup', 'New-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
@@ -311,7 +320,7 @@ function Set-TargetResource
     if ($null -eq $dag)
     {
         # Create a copy of the original parameters
-        $originalPSBoundParameters = @{} + $PSBoundParameters
+        $originalPSBoundParameters = @{ } + $PSBoundParameters
 
         # Remove parameters that don't exist in New-DatabaseAvailabilityGroup
         Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToKeep "Name", "DatabaseAvailabilityGroupIpAddresses", "WitnessDirectory", "WitnessServer", "DomainController"
@@ -334,7 +343,7 @@ function Set-TargetResource
     if ($null -ne $dag)
     {
         # convert Name to Identity, and Remove Credential
-        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{"Identity" = $PSBoundParameters["Name"]}
+        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{"Identity" = $PSBoundParameters["Name"] }
         Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToRemove "Name", "Credential"
 
         # If not all members are in DAG yet, remove params that require them to be
@@ -381,6 +390,10 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AutoDagBitlockerEnabled,
+
+        [Parameter()]
+        [System.Boolean]
         $AutoDagAutoRedistributeEnabled,
 
         [Parameter()]
@@ -468,7 +481,7 @@ function Test-TargetResource
         $WitnessServer
     )
 
-    Write-FunctionEntry -Parameters @{'Name' = $Name} -Verbose:$VerbosePreference
+    Write-FunctionEntry -Parameters @{'Name' = $Name } -Verbose:$VerbosePreference
 
     # Establish remote PowerShell session
     Get-RemoteExchangeSession -Credential $Credential -CommandsToLoad 'Get-DatabaseAvailabilityGroup' -Verbose:$VerbosePreference
@@ -513,6 +526,11 @@ function Test-TargetResource
         }
 
         if (!(Test-ExchangeSetting -Name 'AlternateWitnessServer' -Type 'String' -ExpectedValue $AlternateWitnessServer -ActualValue $dag.AlternateWitnessServer -PSBoundParametersIn $PSBoundParameters -Verbose:$VerbosePreference))
+        {
+            $testResults = $false
+        }
+
+        if (!(Test-ExchangeSetting -Name 'AutoDagBitlockerEnabled' -Type 'Boolean' -ExpectedValue $AutoDagBitlockerEnabled -ActualValue $dag.AutoDagBitlockerEnabled -PSBoundParametersIn $PSBoundParameters -Verbose:$VerbosePreference))
         {
             $testResults = $false
         }
@@ -658,6 +676,10 @@ function Get-DatabaseAvailabilityGroupInternal
 
         [Parameter()]
         [System.Boolean]
+        $AutoDagBitlockerEnabled,
+
+        [Parameter()]
+        [System.Boolean]
         $AutoDagAutoRedistributeEnabled,
 
         [Parameter()]
@@ -746,7 +768,7 @@ function Get-DatabaseAvailabilityGroupInternal
     )
 
     Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{
-        'Identity' = $PSBoundParameters['Name']
+        'Identity'    = $PSBoundParameters['Name']
         'ErrorAction' = 'SilentlyContinue'
     }
     Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToKeep 'Identity', 'ErrorAction', 'DomainController'

--- a/DSCResources/MSFT_xExchDatabaseAvailabilityGroup/MSFT_xExchDatabaseAvailabilityGroup.schema.mof
+++ b/DSCResources/MSFT_xExchDatabaseAvailabilityGroup/MSFT_xExchDatabaseAvailabilityGroup.schema.mof
@@ -18,6 +18,7 @@ class MSFT_xExchDatabaseAvailabilityGroup : OMI_BaseResource
     [Write] Boolean AutoDagDiskReclaimerEnabled;
     [Write] SInt32 AutoDagTotalNumberOfDatabases;
     [Write] String AutoDagVolumesRootFolderPath;
+    [Write] Boolean AutoDagBitlockerEnabled;
     [Write] String DatabaseAvailabilityGroupIpAddresses[];
     [Write, ValueMap{"Off","DagOnly"}, Values{"Off","DagOnly"}] String DatacenterActivationMode;
     [Write] String DomainController;


### PR DESCRIPTION
#### Pull Request (PR) description
Add the AutoDagBitlockerEnabled parameter from Set-DatabaseAvailabilityGroup cmdlet to DSC resource MSFT_xExchDatabaseAvailabilityGroup to support DAGs with Bitlocker encrypted volumes.

#### This Pull Request (PR) fixes the following issues
none

#### Task list

- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/420)
<!-- Reviewable:end -->
